### PR TITLE
Fix typo in week grid layout comment

### DIFF
--- a/app_components/week_grid_layout.py
+++ b/app_components/week_grid_layout.py
@@ -43,7 +43,7 @@ def render_week_grid(clicked_date, df):
 
     total_rows = event_rows + 1
 
-    # Build CSS--grid event-block divs that are clikcable
+    # Build CSS--grid event-block divs that are clickable
     event_blocks = []
     for idx, row in df_assigned.iterrows():
         raw_start_days = (row['StartDate'] - week_start).total_seconds() / (24 * 3600)


### PR DESCRIPTION
## Summary
- fix typo in comment inside week grid layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843705f1174832f8ad09f9b8cb68579