### PR TITLE
fix: type annotate triggered id in modal

### DIFF
--- a/app_components/callbacks.py
+++ b/app_components/callbacks.py
@@ -260,8 +260,10 @@ def register_callbacks(app):
         prevent_initial_call=True,
     )
     def show_event_modal(weekly_click, day_click, close_clicks, timer_tick, close_day_clicks, grid_clicks, week_offset, screen_width):
+        from typing import Any, cast
+
         ctx = dash.callback_context
-        triggered_id = ctx.triggered_id
+        triggered_id = cast(Any, ctx.triggered_id)
 
         if triggered_id == "close-timer":
             return no_update, '', '', 0, None, {'display': 'none'}, '', ''


### PR DESCRIPTION
## Summary
- handle dash.ctx typing in `show_event_modal`

## Testing
- `python -m py_compile app.py app_components/*.py`
- `isort . --check-only` *(fails: imports unsorted)*
- `black --check .` *(fails: files would be reformatted)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441afc8b4c832f9aa999bfffb8986f