### PR TITLE
fix: reduce font sizes for mobile

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -56,11 +56,11 @@
 /* Font and spacing adjustments for mobile */
 @media (max-width: 480px) {
     :root {
-        --font-xs: 0.5rem;
-        --font-small: 0.625rem;
-        --font-base: 0.75rem;
-        --font-subtitle: 0.875rem;
-        --font-title: 1rem;
+        --font-xs: 0.45rem;
+        --font-small: 0.55rem;
+        --font-base: 0.7rem;
+        --font-subtitle: 0.85rem;
+        --font-title: 0.9rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- define missing CSS variables and tweak default font sizes
- reduce font sizes for tablet and mobile breakpoints

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .` *(fails: F401, E501, W293, F541, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848f438c4a4832f962c2e36eec708fd