### PR TITLE
fix: show correct event details from CSS grid

### DIFF
--- a/app_components/callbacks.py
+++ b/app_components/callbacks.py
@@ -353,6 +353,7 @@ def register_callbacks(app):
                 df_week, week_start, week_start + timedelta(days=7)
             )
             df_assigned = assign_event_rows(df_annot, week_start)
+            df_assigned = df_assigned.set_index("orig_index")
 
             if idx not in df_assigned.index:
                 return (

--- a/app_components/plotting.py
+++ b/app_components/plotting.py
@@ -93,6 +93,10 @@ def get_color():
 
 # Add arrow indicators for events that span outside the week
 def annotate_events_with_flags(events_df, week_start, week_end):
+    events_df = events_df.copy()
+    # Preserve the original index so CSS grid clicks can reference the global row
+    events_df["orig_index"] = events_df.index
+
     # Add a duration column for sorting, and sort by: both left and right arrows, only left arrow, fully within week, and only right arrow
     events_df["Duration"] = (
         events_df["EndDate"] - events_df["StartDate"]
@@ -112,6 +116,7 @@ def annotate_events_with_flags(events_df, week_start, week_end):
 
     events_df["overflow_sort"] = events_df.apply(get_overflow_priority, axis=1)
 
+    # Sort events and drop the previous index, but keep the preserved orig_index column
     return events_df.sort_values(
         by=["overflow_sort", "StartDate", "EndDate", "Duration", "Casino"],
         ascending=[True, True, True, False, True],

--- a/app_components/week_grid_layout.py
+++ b/app_components/week_grid_layout.py
@@ -4,9 +4,13 @@ from math import floor
 import pandas as pd
 from dash import html
 
-from .plotting import (annotate_events_with_flags, assign_event_rows,
-                       filter_long_spanning_events, filter_week_events,
-                       get_color)
+from .plotting import (
+    annotate_events_with_flags,
+    assign_event_rows,
+    filter_long_spanning_events,
+    filter_week_events,
+    get_color,
+)
 from .utils import PDT, get_week_range
 
 
@@ -78,7 +82,7 @@ def render_week_grid(clicked_date, df):
         event_blocks.append(
             html.Button(
                 text,
-                id={"type": "grid-event", "index": idx},
+                id={"type": "grid-event", "index": row.get("orig_index", idx)},
                 n_clicks=0,
                 className=" ".join(cls),
                 style={


### PR DESCRIPTION
## Summary
- preserve original data index when annotating events
- use `orig_index` for CSS grid event IDs
- fetch modal details by global index to prevent mismatched info

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort . --profile black --check-only`
- `flake8 .` *(fails: E501 line too long and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684cb6a55000832fb06f4b2f8e9fe5f4