### PR TITLE
fix: avoid plotly warning on hidden graph

### DIFF
--- a/app_components/callbacks.py
+++ b/app_components/callbacks.py
@@ -158,13 +158,7 @@ def register_callbacks(app):
         week_start = current_sunday + timedelta(weeks=week_offset)
 
         if not show_chart:
-            hidden_graph = dcc.Graph(
-                id="weekly-graph",
-                figure={},
-                style={"display": "none"},
-            )
             container = html.Div(
-                hidden_graph,
                 id=f"week-chart-{week_offset}",
                 style={"display": "none"},
             )


### PR DESCRIPTION
## Summary
- remove hidden graph object when Plotly grid is disabled

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_68522e8f1488832f94d8185ce3d8a655