### PR TITLE
fix: keep short events within mobile grid

### DIFF
--- a/app_components/week_grid_layout.py
+++ b/app_components/week_grid_layout.py
@@ -53,9 +53,11 @@ def render_week_grid(clicked_date, df, screen_width=1024):
 
         row_num = row["row_num"] + 2
 
+        duration_days = visible_end - visible_start
+
         # Percentage offsets for fractional placement
         left_pct = (visible_start / 7) * 100
-        width_pct = ((visible_end - visible_start) / 7) * 100
+        width_pct = (duration_days / 7) * 100
 
         # Trim label based on span width and screen size
         label = row["EventName"]
@@ -75,6 +77,10 @@ def render_week_grid(clicked_date, df, screen_width=1024):
             cls.append("arrow-left")
         if row["has_right_arrow"]:
             cls.append("arrow-right")
+
+        # Tighten padding for short events on small screens
+        if duration_days < 0.5 and screen_width < 480:
+            cls.append("short-span")
 
         event_blocks.append(
             html.Button(

--- a/assets/calendar_grid.css
+++ b/assets/calendar_grid.css
@@ -163,3 +163,15 @@
 .week-grid>.day-label-grid:nth-child(7) {
     border-right: 2px solid var(--color-border-primary);
 }
+
+@media (max-width: 480px) {
+    .day-label-grid {
+        font-size: var(--font-small);
+    }
+    .event-block-grid.short-span {
+        padding-left: 0;
+        padding-right: 0;
+        border-left: none;
+        border-right: none;
+    }
+}

--- a/assets/components.css
+++ b/assets/components.css
@@ -14,6 +14,7 @@ h1,
     color: var(--color-accent);
     gap: var(--gap-legend);
     margin-bottom: var(--padding-small);
+    width: 100%;
 }
 
 .legend-text {


### PR DESCRIPTION
## Summary
- remove overflow arrow padding logic
- flag events shorter than 12h and reduce their side padding on small screens
- keep mobile day label font-size tweak

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_6852b43316d8832fbde968a74224bde4