### PR TITLE
feat: enlarge header fonts on wide screens

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -21,6 +21,10 @@
     --font-weight-bold: bold;
     --font-weight-normal: normal;
 
+    /* Larger screen font sizes */
+    --font-title-lg: 2rem;
+    --font-subtitle-lg: 1.5rem;
+
     /* Colors */
     --color-primary-dark: #00008B;
     --color-accent: #6A5ACD;

--- a/assets/components.css
+++ b/assets/components.css
@@ -143,3 +143,20 @@ h1,
     text-align: center;
     padding: var(--padding-base);
 }
+
+/* Larger screen adjustments for sticky header */
+@media (min-width: 1024px) {
+    .sticky-header .calendar-title {
+        font-size: var(--font-title-lg);
+    }
+
+    .sticky-header .legend-title,
+    .sticky-header .legend-text,
+    .sticky-header .week-label {
+        font-size: var(--font-subtitle-lg);
+    }
+
+    .sticky-header .emoji-button {
+        font-size: var(--font-title-lg);
+    }
+}


### PR DESCRIPTION
## Summary
- define large font variables
- increase sticky header font sizes for large screens

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_6852be8c4c30832fb4700d1f9d9319af