### PR TITLE
feat: add offer type categorization

### DIFF
--- a/app_components/callbacks.py
+++ b/app_components/callbacks.py
@@ -381,6 +381,7 @@ def register_callbacks(app):
                 "StartDate",
                 "EndDate",
                 "Offer",
+                "OfferType",
             ]:
                 if label in row:
                     display_label = {
@@ -473,6 +474,7 @@ def register_callbacks(app):
                     "StartDate",
                     "EndDate",
                     "Offer",
+                    "OfferType",
                 ]:
                     if label in data:
                         display_label = {

--- a/app_components/data.py
+++ b/app_components/data.py
@@ -1,6 +1,59 @@
+import re
+
 import pandas as pd
 
 from .utils import PDT
+
+
+def categorize_offer_type(offer_text: str) -> str:
+    """Return a normalized offer category for ``offer_text``."""
+
+    if not isinstance(offer_text, str):
+        return "Unknown"
+
+    text = offer_text.lower()
+
+    free_play_keywords = [
+        "free play",
+        "freeplay",
+        "promo play",
+        "slot credit",
+        "slot play",
+        "bonus play",
+    ]
+    if any(keyword in text for keyword in free_play_keywords):
+        return "Free-Play"
+
+    drawing_keywords = [
+        "hot seat",
+        "drawing",
+        "cash giveaway",
+        "swipe & win",
+        "swipe and win",
+    ]
+    if any(keyword in text for keyword in drawing_keywords):
+        return "Drawings"
+
+    if re.search(r"\b\d+x\s*points\b", text) or "multiplier" in text:
+        return "Point-Based"
+    if "tier credit" in text or "earn & get" in text or "earn and get" in text:
+        return "Point-Based"
+    if re.search(r"earn.*\d+.*points", text):
+        return "Point-Based"
+
+    giveaway_keywords = [
+        "gift giveaway",
+        "pickup",
+        "hotel stay",
+        "hotel room",
+        "dining credit",
+        "gas card",
+        "voucher",
+    ]
+    if any(keyword in text for keyword in giveaway_keywords):
+        return "Giveaways"
+
+    return "Unknown"
 
 
 def load_event_data(csv_path="casino_events.csv"):
@@ -12,5 +65,7 @@ def load_event_data(csv_path="casino_events.csv"):
             df[col] = df[col].dt.tz_localize(PDT)
         else:
             df[col] = df[col].dt.tz_convert(PDT)
+
+    df["OfferType"] = df["Offer"].apply(categorize_offer_type)
 
     return df

--- a/app_components/plotting.py
+++ b/app_components/plotting.py
@@ -544,7 +544,15 @@ def generate_day_view_html(events_df, clicked_date, get_color_fn, screen_width=1
         center_y = top_px + height_px / 2
         center_x = left_pct + width_pct / 2
         event_data = row[
-            ["EventName", "Casino", "Location", "StartDate", "EndDate", "Offer"]
+            [
+                "EventName",
+                "Casino",
+                "Location",
+                "StartDate",
+                "EndDate",
+                "Offer",
+                "OfferType",
+            ]
         ].to_dict()
 
         click_markers.append(


### PR DESCRIPTION
## Summary
- categorize offer strings into 4 OfferType buckets
- attach OfferType to events when loading data
- include OfferType in modals and event customdata

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`
- `python app.py` *(startup check)*

------
https://chatgpt.com/codex/tasks/task_e_68530c15d8ec832fb34d00c94b3a9a03