### PR TITLE
feat: make css grid default and fix sticky header

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A personal Dash application that displays casino events on a responsive calendar
 
 - Weekly calendar view with color‑coded event blocks
 - Modal windows for detailed event and day information
-- Toggle to show or hide a CSS grid layout preview
+- Built-in CSS grid layout preview
 - Toggle to show or hide the Plotly weekly grid
 - Responsive design for desktop, tablet and mobile
 - Time zone normalized to Pacific Time (PDT)

--- a/app_components/callbacks.py
+++ b/app_components/callbacks.py
@@ -90,30 +90,12 @@ def register_callbacks(app):
         return desired_offset, prev_disabled, next_disabled, next_title
 
     @app.callback(
-        Output("show-css-grid", "data"),
-        Output("preview-grid-button", "children"),
-        Input("preview-grid-button", "n_clicks"),
-        State("show-css-grid", "data"),
-        prevent_initial_call=True,
-    )
-    def toggle_css_grid(n_clicks, current_state):
-        if n_clicks is None:
-            raise dash.exceptions.PreventUpdate
-
-        new_state = not current_state
-        label = "Hide CSS Layout" if new_state else "Show CSS Layout"
-        return new_state, label
-
-    @app.callback(
         Output("dev-preview-output", "children"),
         Input("week-offset", "data"),
-        Input("show-css-grid", "data"),
         Input("screen-width", "data"),
         prevent_initial_call=True,
     )
-    def show_dev_preview(week_offset, show_grid, screen_width):
-        if not show_grid:
-            return html.Div()
+    def show_dev_preview(week_offset, screen_width):
 
         today = datetime.now(PDT)
         current_sunday = today - timedelta(days=(today.weekday() + 1) % 7)

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -14,17 +14,6 @@ def create_layout(app):
                 id="app-header",
                 children=[
                     sticky_header(),
-                    # Optional Dev Preview Section
-                    html.Div(
-                        id="day-preview-toggle",
-                        children=html.Button(
-                            "Show CSS Layout",
-                            id="preview-grid-button",
-                            n_clicks=0,
-                            className="emoji-button",
-                        ),
-                        style={"textAlign": "center", "marginBottom": "20px"},
-                    ),
                     dcc.Loading(
                         id="day-preview-loading",
                         type="circle",
@@ -70,7 +59,6 @@ def create_layout(app):
             dcc.Store(id="week-offset", data=0),
             dcc.Store(id="overflow-date"),
             dcc.Store(id="show-plotly-grid", data=False),
-            dcc.Store(id="show-css-grid", data=False),
             dcc.Store(id="animation-refresh"),
             html.Div(id="animation-dummy", style={"display": "none"}),
             # Interval Triggers
@@ -181,7 +169,8 @@ def sticky_header():
             ),
             # Week Label
             html.Div(id="week-label", className="fade-text week-label", children=""),
-        ]
+        ],
+        className="sticky-header",
     )
 
 

--- a/handoff.md
+++ b/handoff.md
@@ -52,7 +52,7 @@ casino_calendar/
 ### Grid Layout Preview
 
 - `week_grid_layout.py` renders a grid-style week calendar
-- Injected into `dev-preview-output` and toggled via `preview-grid-button`
+- Injected into `dev-preview-output` and always visible
 
 ### Scrollable Body
 


### PR DESCRIPTION
## Summary
- remove CSS layout toggle button
- always show CSS grid preview
- ensure sticky header class is applied
- update docs for default grid preview

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_6854cb9d8bd4832f85b0edd790dff36c