### PR TITLE
fix: apply short-span styling on all screens

### DIFF
--- a/app_components/week_grid_layout.py
+++ b/app_components/week_grid_layout.py
@@ -78,8 +78,8 @@ def render_week_grid(clicked_date, df, screen_width=1024):
         if row["has_right_arrow"]:
             cls.append("arrow-right")
 
-        # Tighten padding for short events on small screens
-        if duration_days < 0.5 and screen_width < 480:
+        # Mark short events for additional styling
+        if duration_days < 0.5:
             cls.append("short-span")
 
         event_blocks.append(

--- a/assets/calendar_grid.css
+++ b/assets/calendar_grid.css
@@ -175,3 +175,8 @@
         border-right: none;
     }
 }
+
+.event-block-grid.short-span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}


### PR DESCRIPTION
## Summary
- ensure `.short-span` class is added regardless of screen width
- move overflow rules outside media query so short events truncate text on all devices

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_68553333d538832f8c4ad2424304a933