### PR TITLE
refactor: centralize css variables

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -53,6 +53,20 @@
     /* Modal sizing */
     --modal-max-width: 600px;
     --modal-max-height: 80vh;
+    --modal-min-height: 300px;
+    --modal-width: 90%;
+    --modal-width-mobile: 85%;
+    --day-modal-max-height: 800px;
+    --modal-max-height-mobile: 70vh;
+    --event-modal-max-width-tablet: 500px;
+    --day-modal-max-width-tablet: 700px;
+    --modal-overlay-color: rgba(0, 0, 0, 0.25);
+    --modal-overlay-blur: 4px;
+
+    /* Animation distances */
+    --slide-distance: 500px;
+    --overflow-expand-max-height: 500px;
+    --week-content-max-height: 1500px;
 
     /* Row heights */
     --header-row-height: 3.5rem;

--- a/assets/styles/animations.css
+++ b/assets/styles/animations.css
@@ -10,7 +10,7 @@
 }
 
 .overflow-box-expand.show {
-    max-height: 500px;
+    max-height: var(--overflow-expand-max-height);
     opacity: 1;
     pointer-events: auto;
     transition-delay: 0.4s, 0.8s;
@@ -26,7 +26,7 @@
 }
 
 .week-content.show {
-    max-height: 1500px;
+    max-height: var(--week-content-max-height);
     opacity: 1;
     pointer-events: auto;
     transition-delay: 0.4s, 0s;
@@ -55,7 +55,7 @@
 
 @keyframes slideIn {
     from {
-        transform: translateY(500px);
+        transform: translateY(var(--slide-distance));
         opacity: 0;
     }
 
@@ -72,7 +72,7 @@
     }
 
     to {
-        transform: translateY(500px);
+        transform: translateY(var(--slide-distance));
         opacity: 0;
     }
 }

--- a/assets/styles/calendar_grid.css
+++ b/assets/styles/calendar_grid.css
@@ -11,8 +11,8 @@
 }
 
 .grid-filler-cell {
-    border-left: 1px solid var(--color-border-grid);
-    border-right: 1px solid var(--color-border-grid);
+    border-left: var(--border-thin) solid var(--color-border-grid);
+    border-right: var(--border-thin) solid var(--color-border-grid);
     box-sizing: border-box;
     min-height: var(--event-row-height);
     pointer-events: none;
@@ -100,8 +100,8 @@
     font-size: var(--font-base);
     padding: var(--padding-small);
     margin-bottom: var(--gap-week);
-    border-left: 1px solid var(--color-border-grid);
-    border-right: 1px solid var(--color-border-grid);
+    border-left: var(--border-thin) solid var(--color-border-grid);
+    border-right: var(--border-thin) solid var(--color-border-grid);
     border-radius: var(--border-radius-xs);
     border-top: none;
     border-bottom: none;
@@ -144,7 +144,7 @@
 
 /* 6. Rounded off grid edges */
 .day-label-wrapper>.day-label-grid:nth-child(1) {
-    border-left: 2px solid var(--color-border-primary);
+    border-left: var(--border-thick) solid var(--color-border-primary);
 }
 
 .day-label-wrapper>.day-label-grid:nth-child(2),
@@ -153,11 +153,11 @@
 .day-label-wrapper>.day-label-grid:nth-child(5),
 .day-label-wrapper>.day-label-grid:nth-child(6),
 .day-label-wrapper>.day-label-grid:nth-child(7) {
-    border-left: 2px solid var(--color-border-primary);
+    border-left: var(--border-thick) solid var(--color-border-primary);
 }
 
 .day-label-wrapper>.day-label-grid:last-child {
-    border-right: 2px solid var(--color-border-primary);
+    border-right: var(--border-thick) solid var(--color-border-primary);
 }
 
 @media (max-width: 480px) {

--- a/assets/styles/components.css
+++ b/assets/styles/components.css
@@ -37,8 +37,8 @@ h1,
 }
 
 .legend-color-box {
-    width: 12px;
-    height: 12px;
+    width: var(--arrow-width);
+    height: var(--arrow-width);
     display: inline-block;
     border-radius: var(--padding-xs);
     margin-right: var(--padding-xs);

--- a/assets/styles/modal.css
+++ b/assets/styles/modal.css
@@ -32,9 +32,9 @@
     left: 0;
     right: 0;
     bottom: 0;
-    -webkit-backdrop-filter: blur(4px);
-    backdrop-filter: blur(4px);
-    background-color: rgba(0, 0, 0, 0.25);
+    -webkit-backdrop-filter: blur(var(--modal-overlay-blur));
+    backdrop-filter: blur(var(--modal-overlay-blur));
+    background-color: var(--modal-overlay-color);
     z-index: -1;
     pointer-events: none;
 }
@@ -67,8 +67,8 @@
     box-shadow: var(--box-shadow-modal);
     max-height: auto;
     max-width: auto;
-    min-height: 300px;
-    width: 600px;
+    min-height: var(--modal-min-height);
+    width: var(--modal-max-width);
     min-width: unset;
     color: black;
     font-size: var(--font-base);
@@ -92,7 +92,7 @@
 
 /* Dynamic sizing for event modal */
 #event-modal-content {
-    width: 90%;
+    width: var(--modal-width);
     max-width: var(--modal-max-width);
     max-height: var(--modal-max-height);
     display: flex;
@@ -108,8 +108,8 @@
 
 /* Responsive Day Modal Enhancements */
 #day-modal-content {
-    width: 90%;
-    max-height: 800px;
+    width: var(--modal-width);
+    max-height: var(--day-modal-max-height);
 }
 
 #day-modal-body {
@@ -124,29 +124,29 @@
 /* Modal Responsiveness */
 @media (max-width: 768px) {
     #event-modal-content {
-        max-width: 500px;
+        max-width: var(--event-modal-max-width-tablet);
     }
 
     #day-modal-content {
-        max-width: 700px;
+        max-width: var(--day-modal-max-width-tablet);
     }
 
     #day-modal-body {
-        max-height: 80vh;
+        max-height: var(--modal-max-height);
     }
 }
 
 @media (max-width: 480px) {
     #event-modal-content {
-        width: 85% !important;
+        width: var(--modal-width-mobile) !important;
     }
 
     #day-modal-content {
-        width: 85% !important;
+        width: var(--modal-width-mobile) !important;
     }
 
     #day-modal-body {
-        max-height: 70vh;
+        max-height: var(--modal-max-height-mobile);
         font-size: var(--font-small);
     }
 }


### PR DESCRIPTION
## Summary
- introduce reusable variables in `base.css`
- replace hardcoded values with CSS variables in `modal.css`
- use variables for animation metrics
- unify grid borders with variables
- share arrow size for legend color boxes

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`
- `python app.py` *(confirmed server starts)*


------
https://chatgpt.com/codex/tasks/task_e_6867a9165be4832fa8b7b2436d0f63ce