### PR TITLE
refactor: rely on css classes for layout

### DIFF
--- a/app_components/callbacks.py
+++ b/app_components/callbacks.py
@@ -118,10 +118,10 @@ def register_callbacks(app, df):
                 children=[
                     html.Strong(
                         "Ongoing Events This Week:",
+                        className="font-bold mb-section",
                         style={
                             "color": "#6A5ACD",
                             "display": "block",
-                            "marginBottom": "8px",
                         },
                     ),
                     html.Ul(
@@ -383,9 +383,7 @@ def register_callbacks(app, df):
                     rows.append(
                         html.Div(
                             [
-                                html.Strong(
-                                    f"{display_label}: ", style={"color": "#6A5ACD"}
-                                ),
+                                html.Strong(f"{display_label}: "),
                                 html.Span(value),
                             ],
                             className="event-label",
@@ -481,9 +479,7 @@ def register_callbacks(app, df):
                         rows.append(
                             html.Div(
                                 [
-                                    html.Strong(
-                                        f"{display_label}: ", style={"color": "#6A5ACD"}
-                                    ),
+                                    html.Strong(f"{display_label}: "),
                                     html.Span(value),
                                 ],
                                 className="event-label",

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -36,7 +36,8 @@ def create_layout(app, df):
                                     n_clicks=0,
                                     className="emoji-button",
                                 ),
-                                style={"textAlign": "center", "marginBottom": "20px"},
+                                className="mb-section",
+                                style={"textAlign": "center"},
                             ),
                             # Main calendar area
                             dcc.Loading(
@@ -104,10 +105,6 @@ def create_layout(app, df):
                             html.Div(
                                 id="day-modal-body",
                                 className="base-padding",
-                                style={
-                                    "maxHeight": "80vh",
-                                    "overflowY": "auto",
-                                },
                             ),
                             html.Button(
                                 "Close", id="close-day-modal", className="modal-close"

--- a/app_components/week_grid_layout.py
+++ b/app_components/week_grid_layout.py
@@ -124,5 +124,4 @@ def render_week_grid(clicked_date, df, screen_width=1024):
     return html.Div(
         children=[header_row] + event_blocks + grid_fillers,
         className="week-grid",
-        style={"gridTemplateRows": "var(--header-row-height) auto"},
     )


### PR DESCRIPTION
## Summary
- drop redundant inline styles in layout components
- tidy week grid return structure
- clean event callback formatting

## Testing
- `black . && isort . && flake8 .`
- `python -m py_compile app.py app_components/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6868b0d2d244832f8c8a6843a3c33a86