### PR TITLE
fix: narrow landscape mobile breakpoint

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -66,7 +66,7 @@
   --arrow-width: 0.75rem; }
 
 /* Font and spacing adjustments for mobile */
-@media (max-width: 480px) {
+@media (max-width: 480px), (max-width: 896px) and (orientation: landscape) {
   :root {
     --font-xs: 0.45rem;
     --font-small: 0.55rem;

--- a/assets/style.css
+++ b/assets/style.css
@@ -60,6 +60,9 @@
   @media (max-width: 768px) {
     .sticky-header {
       position: static; } }
+  @media (max-width: 896px) and (orientation: landscape) {
+    .sticky-header {
+      position: static; } }
 /* Headers */
 h1,
 .calendar-title {
@@ -335,7 +338,7 @@ h1,
 .day-label-wrapper > .day-label-grid:last-child {
   border-right: var(--border-thick) solid var(--color-border-primary); }
 
-@media (max-width: 480px) {
+@media (max-width: 480px), (max-width: 896px) and (orientation: landscape) {
   .day-label-grid {
     font-size: var(--font-small); }
   .event-block-grid.short-span {
@@ -466,7 +469,7 @@ h1,
   #day-modal-body {
     max-height: var(--modal-max-height); } }
 
-@media (max-width: 480px) {
+@media (max-width: 480px), (max-width: 896px) and (orientation: landscape) {
   #event-modal-content {
     width: var(--modal-width-mobile) !important; }
   #day-modal-content {

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -73,4 +73,9 @@
     @include tablet {
         position: static;
     }
+
+    // Disable sticky header for landscape phones
+    @media (max-width: 896px) and (orientation: landscape) {
+        position: static;
+    }
 }

--- a/assets/styles/_mixins.scss
+++ b/assets/styles/_mixins.scss
@@ -1,5 +1,7 @@
 @mixin mobile {
-  @media (max-width: 480px) {
+  // Maintain mobile styles when devices are rotated to landscape
+  @media (max-width: 480px),
+         (max-width: 896px) and (orientation: landscape) {
     @content;
   }
 }


### PR DESCRIPTION
## Summary
- treat rotated mobile devices up to 896px wide as mobile
- keep sticky header static at this narrower breakpoint
- adjust compiled CSS and base variables accordingly

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_6868ba389d34832fb0c25fca8944fa6f