### PR TITLE
docs: add nested AGENTS files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,11 @@
 # AGENTS Instructions for Casino Event Calendar
 
 These guidelines outline how to format code and validate changes for this Dash
-application.
+application. See the **Contributing** section in `README.md` for workflow tips
+and a link to the project's Git cheat‑sheet.
+
+Directory-specific instructions can be found in
+`app_components/AGENTS.md` and `assets/styles/AGENTS.md`.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Hosted at [https://casino-calendar.onrender.com](https://casino-calendar.onrende
 web: gunicorn app:server
 ```
 
+## 🤝 Contributing
+
+Please follow the development guidelines in `AGENTS.md` when proposing
+changes. Run the formatters and linters before committing and see
+`GIT-CHEATSHEET.md` for handy Git commands.
+
 ## 🧼 License
 
 Released under [The Unlicense](https://unlicense.org).

--- a/app_components/AGENTS.md
+++ b/app_components/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS instructions for `app_components`
+
+This directory contains the Python modules for the Dash application.
+
+- Follow the style and tooling described in the repository root `AGENTS.md`.
+- Keep functions small and focused with type hints and docstrings.
+- Avoid side effects and prefer returning new values over mutating arguments.
+- Split out helpers if a file grows beyond roughly 400 lines.
+- Check syntax before committing:
+  ```bash
+  python -m py_compile *.py
+  ```
+
+*[End of app_components guidelines]*

--- a/assets/styles/AGENTS.md
+++ b/assets/styles/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS instructions for `assets/styles`
+
+SCSS partials in this folder are combined into `../style.scss` and compiled to `../style.css`.
+
+- Use BEM-like class names and keep selectors narrow.
+- Place design tokens in `_variables.scss` and reusable code in `_mixins.scss`.
+- After editing SCSS files, regenerate `style.css` if the `sass` command is available:
+  ```bash
+  sass ../style.scss ../style.css
+  ```
+- Do not commit compiled CSS changes if the only updates are in SCSS.
+
+*[End of styles guidelines]*


### PR DESCRIPTION
## Summary
- add AGENTS instructions for the Python modules under `app_components`
- add AGENTS instructions for the SCSS partials in `assets/styles`
- note these directory-specific guides in the root AGENTS

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_686a0ee4b470832f91204b070d275f74