### PR TITLE
fix: keep day headers sticky on large screens

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -29,6 +29,7 @@
 
 .week-chart-scroll {
   overflow-x: visible;
+  overflow-y: auto;
   padding: 0 var(--padding-small) calc(var(--padding-base) * 3);
   margin-bottom: 0; }
 

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -38,6 +38,7 @@
 
 .week-chart-scroll {
     overflow-x: visible;
+    overflow-y: auto;
     padding: 0 var(--padding-small) calc(var(--padding-base) * 3);
     margin-bottom: 0;
 }


### PR DESCRIPTION
## Summary
- ensure week charts scroll within their container
- update compiled CSS

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_686a108f6664832faeac4f2ae7341c23