### PR TITLE
fix: keep day headers sticky on large screens

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -27,6 +27,10 @@
   box-sizing: border-box;
   background-color: var(--color-background); }
 
+@media (min-width: 1024px) {
+  .calendar-scroll-body {
+    overflow-y: visible; } }
+
 .week-chart-scroll {
   overflow-x: visible;
   padding: 0 var(--padding-small) calc(var(--padding-base) * 3);

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -36,8 +36,15 @@
     background-color: var(--color-background);
 }
 
+@include desktop {
+    .calendar-scroll-body {
+        overflow-y: visible;
+    }
+}
+
 .week-chart-scroll {
     overflow-x: visible;
+    overflow-y: auto;
     padding: 0 var(--padding-small) calc(var(--padding-base) * 3);
     margin-bottom: 0;
 }


### PR DESCRIPTION
## Summary
- prevent calendar body from scrolling on desktop
- update compiled CSS

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_686a108f6664832faeac4f2ae7341c23