### PR TITLE
feat: reload page when clicking title

### DIFF
--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -98,9 +98,11 @@ def create_layout(app, df):
 def sticky_header(df):
     return html.Div(
         [
-            html.H1(
+            html.Button(
                 "🎰 Casino Event Calendar 📅",
+                id="title-refresh-button",
                 className="calendar-title",
+                type="button",
             ),
             # Navigation & Legend
             html.Div(

--- a/assets/reload.js
+++ b/assets/reload.js
@@ -1,0 +1,9 @@
+// Reload the page when the title button is clicked
+window.addEventListener('DOMContentLoaded', () => {
+  const button = document.getElementById('title-refresh-button');
+  if (button) {
+    button.addEventListener('click', () => {
+      window.location.reload();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- refresh the page when clicking the header title
- add small helper script to trigger reload

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_686ac48ee1d8832fb5450f274c671804