### PR TITLE
chore: add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "casino-calendar",
+  "version": "1.0.0",
+  "description": "Dash casino event calendar assets",
+  "private": true,
+  "scripts": {
+    "build:css": "sass assets/style.scss assets/style.css",
+    "watch:css": "sass --watch assets/style.scss assets/style.css"
+  },
+  "devDependencies": {
+    "sass": "^1.77.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add a basic `package.json` with scripts to compile SCSS

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_686ba8fa64dc832f9b6720772c67ea41