### PR TITLE
docs: refresh guidelines and readme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ These tools are installed via `requirements.txt`.
 - Use variables defined in `assets/base.css`.
 - Keep styles modular in `assets/*` and avoid global overrides.
 - Follow a BEM‑like naming style (e.g., `.week-grid`, `.event-block-grid`).
+- Compile SCSS with `npm run build:css` and watch with `npm run watch:css`
 
 ## Programmatic checks
 
@@ -123,6 +124,8 @@ source .venv/bin/activate  # on Windows use .\.venv\Scripts\activate
 
 ```bash
 pip install -r requirements.txt
+npm install
+npm run build:css
 ```
 
 Run the formatters and linter:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A personal Dash application that displays casino events on a responsive calendar
 - Responsive design for desktop, tablet and mobile
 - Time zone normalized to Pacific Time (PDT)
 - Toggle to show ongoing events that span the week
-- Auto-categorizes offer types (Free-Play, Drawings, Giveaways)
+- Auto-categorizes offers into Giveaway, Free-Play, Point-Based, Hospitality-Rewards and Special-Events
+- SCSS styles compiled with Sass
 
 ---
 
@@ -27,8 +28,11 @@ app_components/          # Core logic modules
   plotting.py            # Plotly figure generation
   utils.py               # Helpers and time zone utilities
   week_grid_layout.py    # CSS-based week grid layout
+  legacy.py            # Archived Plotly helpers for reference
 assets/                  # Static assets auto-loaded by Dash
   base.css
+  style.css
+  style.scss
   styles/
     animations.css
     calendar_grid.css
@@ -39,6 +43,7 @@ assets/                  # Static assets auto-loaded by Dash
 casino_events.csv        # Event data
 requirements.txt         # Python dependencies
 Procfile                 # Render deployment
+package.json           # NPM scripts for Sass
 README.md
 ```
 
@@ -48,6 +53,8 @@ README.md
 python3 -m venv .venv
 source .venv/bin/activate  # use .\.venv\Scripts\activate on Windows
 pip install -r requirements.txt  # installs black, isort and flake8
+npm install
+npm run build:css
 pre-commit install
 pre-commit run --all-files
 python -m py_compile app.py app_components/*.py

--- a/app_components/AGENTS.md
+++ b/app_components/AGENTS.md
@@ -5,6 +5,7 @@ This directory contains the Python modules for the Dash application.
 - Follow the style and tooling described in the repository root `AGENTS.md`.
 - Keep functions small and focused with type hints and docstrings.
 - Avoid side effects and prefer returning new values over mutating arguments.
+- `legacy.py` contains deprecated Plotly helpers for reference only.
 - Split out helpers if a file grows beyond roughly 400 lines.
 - Check syntax before committing:
   ```bash

--- a/assets/styles/AGENTS.md
+++ b/assets/styles/AGENTS.md
@@ -6,6 +6,8 @@ SCSS partials in this folder are combined into `../style.scss` and compiled to `
 - Place design tokens in `_variables.scss` and reusable code in `_mixins.scss`.
 - After editing SCSS files, regenerate `style.css` if the `sass` command is available:
   ```bash
+  npm run build:css
+  npm run watch:css # optional for auto-rebuild
   sass ../style.scss ../style.css
   ```
 - Do not commit compiled CSS changes if the only updates are in SCSS.


### PR DESCRIPTION
## Summary
- clarify offer categorization details and SCSS build step in README
- note legacy module and Sass scripts in nested AGENTS files
- mention npm commands in root guidelines

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_686bad317208832fa36e05ad715e7cc5