### PR TITLE
chore: migrate scss to sass modules

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -1,8 +1,8 @@
-@import 'styles/mixins';
-@import 'styles/layout';
-@import 'styles/components';
-@import 'styles/calendar_grid';
-@import 'styles/modal';
-@import 'styles/animations';
-@import 'styles/utilities';
-@import 'styles/legacy';
+@use 'styles/mixins';
+@use 'styles/layout';
+@use 'styles/components';
+@use 'styles/calendar_grid';
+@use 'styles/modal';
+@use 'styles/animations';
+@use 'styles/utilities';
+@use 'styles/legacy';

--- a/assets/styles/_calendar_grid.scss
+++ b/assets/styles/_calendar_grid.scss
@@ -1,3 +1,5 @@
+@use 'mixins' as mixins;
+
 /* 1. Establish a 7-column grid with a header row +event rows */
 .week-grid {
     display: grid;
@@ -160,7 +162,7 @@
     border-right: var(--border-thick) solid var(--color-border-primary);
 }
 
-@include mobile {
+@include mixins.mobile {
     .day-label-grid {
         font-size: var(--font-small);
     }
@@ -173,7 +175,7 @@
     }
 }
 
-@include desktop {
+@include mixins.desktop {
     .day-label-grid {
         font-size: var(--font-base);
     }

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -1,3 +1,5 @@
+@use 'mixins' as mixins;
+
 /* Headers */
 
 h1,
@@ -12,7 +14,7 @@ h1,
     display: block;
     align-items: center;
 
-    @include mobile {
+    @include mixins.mobile {
         font-size: var(--font-header);
     }
 }
@@ -26,7 +28,7 @@ h1,
     margin-bottom: var(--padding-small);
     width: 100%;
 
-    @include mobile {
+    @include mixins.mobile {
         font-size: var(--font-subtitle);
     }
 }

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -1,3 +1,5 @@
+@use 'mixins' as mixins;
+
 /* Layout and Structure */
 
 html,
@@ -6,7 +8,7 @@ body {
     overflow: hidden;
 }
 
-@include mobile {
+@include mixins.mobile {
 
     html,
     body {
@@ -70,7 +72,7 @@ body {
     padding: var(--padding-small);
 }
 
-@include mobile {
+@include mixins.mobile {
     .week-label {
         font-size: var(--font-small);
     }
@@ -92,7 +94,7 @@ body {
     z-index: 100;
     background-color: var(--color-background);
 
-    @include tablet {
+    @include mixins.tablet {
         position: static;
     }
 

--- a/assets/styles/_modal.scss
+++ b/assets/styles/_modal.scss
@@ -1,3 +1,5 @@
+@use 'mixins' as mixins;
+
 /* Modal Container & Behavior */
 .modal {
     position: fixed;
@@ -122,7 +124,7 @@
 }
 
 /* Modal Responsiveness */
-@include tablet {
+@include mixins.tablet {
     #event-modal-content {
         max-width: var(--event-modal-max-width-tablet);
     }
@@ -136,7 +138,7 @@
     }
 }
 
-@include mobile {
+@include mixins.mobile {
     #event-modal-content {
         width: var(--modal-width-mobile) !important;
     }
@@ -151,7 +153,7 @@
     }
 }
 
-@include desktop {
+@include mixins.desktop {
     #event-modal-content {
         max-width: 40rem;
     }
@@ -160,7 +162,7 @@
     }
 }
 
-@include hd {
+@include mixins.hd {
     #event-modal-content {
         max-width: 45rem;
     }

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -1,4 +1,4 @@
-@import 'mixins';
+@use 'mixins' as mixins;
 
 /* CSS Variables for Consistency */
 :root {
@@ -102,7 +102,7 @@
 }
 
 /* Font and spacing adjustments for tablets */
-@include tablet {
+@include mixins.tablet {
     :root {
         --font-xs: 0.55rem;
         --font-small: 0.75rem;
@@ -114,7 +114,7 @@
 }
 
 /* Desktop font adjustments */
-@include desktop {
+@include mixins.desktop {
     :root {
         --font-base: 1.05rem;
         --font-subtitle: 1.3rem;
@@ -123,7 +123,7 @@
     }
 }
 
-@include hd {
+@include mixins.hd {
     :root {
         --font-base: 1.125rem;
         --font-subtitle: 1.5rem;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Dash casino event calendar assets",
   "private": true,
   "scripts": {
-    "build:css": "sass assets/style.scss assets/style.css",
-    "watch:css": "sass --watch assets/style.scss assets/style.css"
+    "build:css": "sass --no-source-map assets/style.scss assets/style.css",
+    "watch:css": "sass --no-source-map --watch assets/style.scss assets/style.css"
   },
   "devDependencies": {
     "sass": "^1.77.0"


### PR DESCRIPTION
## Summary
- replace deprecated `@import` syntax with `@use`
- namespace mixin calls
- disable source maps in the Sass build script

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_686bb585a250832fbd1ebbc7c3832b61