### PR TITLE
chore: add setup script for environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ README.md
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate  # use .\.venv\Scripts\activate on Windows
+./setup.sh                 # install Python and Node dependencies
 pip install -r requirements.txt  # installs black, isort and flake8
 npm install
 npm run build:css

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Setup script for the Codex environment.
+# Installs Python and Node dependencies needed for the Casino Calendar app.
+
+set -e
+
+# Install Python dependencies
+if [ -f requirements.txt ]; then
+    python3 -m pip install --upgrade pip
+    python3 -m pip install -r requirements.txt
+fi
+
+# Install Node dependencies if npm is available
+if command -v npm >/dev/null 2>&1; then
+    npm install
+    npm run build:css
+fi
+
+# Install pre-commit hooks if available
+if command -v pre-commit >/dev/null 2>&1; then
+    pre-commit install
+fi


### PR DESCRIPTION
## Summary
- provide a `setup.sh` script to install Python/Node deps and pre-commit hooks
- document the script in the local setup instructions

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbb20e86c832f83b9ea672f8784bb