### PR TITLE
fix: specify patch version for Python

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,4 +9,4 @@ services:
     startCommand: gunicorn app:server
     envVars:
       - key: PYTHON_VERSION
-        value: 3.11
+        value: 3.11.11


### PR DESCRIPTION
## Summary
- fix Render YAML Python version to include a patch number

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_686ca21d38d8832fb4420f9a7531ce27