### PR TITLE
test: ensure event blocks trigger modal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,10 @@ gunicorn==23.0.0
 black==25.1.0
 isort==6.0.1
 flake8==7.3.0
+psutil==7.0.0
+selenium==4.21.0
+percy==2.0.2
+beautifulsoup4==4.12.3
+freezegun==1.5.0
+# Dash testing utilities
+"dash[testing]==3.1.1"

--- a/tests/test_event_modal.py
+++ b/tests/test_event_modal.py
@@ -1,0 +1,20 @@
+from dash.testing.application_runners import import_app
+from freezegun import freeze_time
+
+
+@freeze_time("2025-04-10")
+def test_event_blocks_open_modal(dash_duo):
+    app = import_app("app")
+    dash_duo.start_server(app)
+
+    dash_duo.wait_for_element(".event-block-grid", timeout=15)
+    event_blocks = dash_duo.find_elements(".event-block-grid")
+    assert event_blocks, "No event blocks found"
+
+    for block in event_blocks:
+        block.click()
+        dash_duo.wait_for_element("#event-modal.modal.show", timeout=10)
+        modal = dash_duo.find_element("#event-modal")
+        assert "show" in modal.get_attribute("class"), "Modal did not open"
+        dash_duo.find_element("#close-modal").click()
+        dash_duo.wait_for_no_elements("#event-modal.modal.show", timeout=10)


### PR DESCRIPTION
## Summary
- add integration test for event modal
- expand requirements for dash testing

## Testing
- `python -m py_compile app.py app_components/*.py tests/test_event_modal.py`
- `black . --check`
- `isort . --check-only`
- `flake8 .`
- `pytest tests/test_event_modal.py -q` *(fails: 'chromedriver' executable needs to be in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_686d8766ed28832faff39e052a2149bf