### PR TITLE
test: handle missing chrome gracefully

### DIFF
--- a/tests/test_event_modal.py
+++ b/tests/test_event_modal.py
@@ -4,8 +4,10 @@ from dash.testing.application_runners import import_app
 from freezegun import freeze_time
 
 try:
-    chromedriver_autoinstaller.install()
-except ValueError:
+    chromedriver_path = chromedriver_autoinstaller.install()
+    if not chromedriver_path:
+        raise RuntimeError("chromedriver install returned no path")
+except Exception:
     pytest.skip(
         "Chrome browser is not available for chromedriver-autoinstaller",
         allow_module_level=True,


### PR DESCRIPTION
## Summary
- skip event modal tests when chromedriver install returns no path

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686db26454f8832f99bde3a6e5ff4ade