### PR TITLE
chore: add editor configs for vscode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 150
+exclude = node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,9 @@ venv/
 Thumbs.db
 
 # IDE settings
-.vscode/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
 .idea/
 
 # Logs and artifacts

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,9 +1,5 @@
-{
-    "MD003": {
-        "style": "atx_closed"
-    },
-    "MD007": {
-        "indent": 4
-    },
-    "no-hard-tabs": false
+{    "MD003": { "style": "atx" },
+    "MD007": { "indent": 2 },
+    "MD013": { "line_length": 120, "strict": false },
+    "no-hard-tabs": true
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["stylelint-config-standard-scss"],
+  "plugins": ["@stylistic/stylelint-plugin"],
+  "rules": {
+    "@stylistic/indentation": 4,
+    "@stylistic/max-empty-lines": 1
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.black-formatter",
+    "stylelint.vscode-stylelint",
+    "davidanson.vscode-markdownlint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "editor.formatOnSave": true,
+  "python.formatting.provider": "black",
+  "python.sortImports.path": "isort",
+  "python.sortImports.args": ["--profile", "black"],
+  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Path": "flake8",
+  "python.linting.pylintEnabled": false,
+  "stylelint.validate": ["css", "scss"],
+  "stylelint.configFile": ".stylelintrc.json",
+  "markdownlint.config": ".markdownlint.json",
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "davidanson.vscode-markdownlint"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🎰 Casino Event Calendar
 
-A personal Dash application that displays casino events on a responsive calendar. Weekly and daily views include interactive modals rendered with a CSS grid layout.
+A personal Dash application that displays casino events on a responsive calendar.
+Weekly and daily views include interactive modals rendered with a CSS grid layout.
 
 ---
 
@@ -68,6 +69,8 @@ web: gunicorn app:server
 Please follow the development guidelines in `AGENTS.md` when proposing
 changes. Run the formatters and linters before committing and see
 `GIT-CHEATSHEET.md` for handy Git commands.
+VSCode users can take advantage of the included `.editorconfig` and
+`.vscode` files so formatting and linting run automatically on save.
 
 ## 🧼 License
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -2,7 +2,8 @@
 
 ## 📌 Overview
 
-A responsive Dash web application that visualizes casino events in a calendar layout. Built with Plotly Dash and deployed on Render.
+A responsive Dash web application that visualizes casino events in a calendar layout.
+Built with Plotly Dash and deployed on Render.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "watch:css": "sass --no-source-map --watch assets/style.scss assets/style.css"
   },
   "devDependencies": {
-    "sass": "^1.77.0"
+    "@stylistic/stylelint-plugin": "^3.1.3",
+    "sass": "^1.77.0",
+    "stylelint": "^16.21.1",
+    "stylelint-config-standard": "^38.0.0",
+    "stylelint-config-standard-scss": "^15.0.1"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 88
+skip-string-normalization = false
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
## Summary
- allow committing vscode configs
- add `.editorconfig` with project rules
- configure VSCode settings and extension recommendations
- mention automated editor setup in README

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`
- stylelint install attempt failed as it required network access


------
https://chatgpt.com/codex/tasks/task_e_686de6497788832fa21781261154ed9b