### PR TITLE
fix: restrict overflow events to span entire week

### DIFF
--- a/app_components/callbacks.py
+++ b/app_components/callbacks.py
@@ -71,7 +71,7 @@ def register_callbacks(app, df):
 
         next_week_offset = desired_offset + 1
         next_week_start = current_sunday + timedelta(weeks=next_week_offset)
-        next_week_end = next_week_start + timedelta(days=6)
+        next_week_end = next_week_start + timedelta(days=7)
 
         has_next_week_events = not df[
             (df["EndDate"] > next_week_start) & (df["StartDate"] < next_week_end)
@@ -105,7 +105,7 @@ def register_callbacks(app, df):
 
         grid = render_week_grid(week_start, df, screen_width)
 
-        week_end = week_start + timedelta(days=6)
+        week_end = week_start + timedelta(days=7)
         overflow_df = filter_long_spanning_events(df, week_start, week_end)
 
         if not overflow_df.empty:

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from app_components.legacy import filter_long_spanning_events
+from app_components.utils import PDT
+
+
+def test_filter_long_spanning_events():
+    week_start = PDT.localize(datetime(2025, 7, 6))
+    week_end = week_start + timedelta(days=7)
+    df = pd.DataFrame(
+        {
+            "EventName": ["A", "B", "C", "D"],
+            "Casino": ["C"] * 4,
+            "StartDate": [
+                week_start - timedelta(days=1),
+                week_start - timedelta(days=1),
+                week_start + timedelta(days=1),
+                week_start - timedelta(days=2),
+            ],
+            "EndDate": [
+                week_end + timedelta(days=1),
+                week_end - timedelta(days=1),
+                week_end + timedelta(days=1),
+                week_end + timedelta(hours=1),
+            ],
+        }
+    )
+
+    result = filter_long_spanning_events(df, week_start, week_end)
+    assert list(result["EventName"]) == ["A", "D"]


### PR DESCRIPTION
## Summary
- adjust week boundary calculations
- add unit test covering long spanning events

## Testing
- `black . --check`
- `isort . --check-only`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f9190d244832facc128c9d145fd98