### PR TITLE
feat: split event block components

### DIFF
--- a/app_components/plotting.py
+++ b/app_components/plotting.py
@@ -175,6 +175,23 @@ def assign_event_rows(events_df, week_start):
     return events_df
 
 
+def create_day_event_block(row, top_px, height_px, left_pct, width_pct, color):
+    """Return a styled div representing a day-view event block."""
+
+    return html.Div(
+        html.Span(row["EventName"], className="event-block-day__label"),
+        title=row["EventName"],
+        className="event-block-day",
+        style={
+            "top": f"{top_px}px",
+            "left": f"{left_pct}%",
+            "width": f"{width_pct}%",
+            "height": f"{height_px}px",
+            "backgroundColor": color,
+        },
+    )
+
+
 # Generate a responsive 24-hour vertical day view with absolutely positioned event blocks.
 def generate_day_view_html(events_df, clicked_date, get_color_fn, screen_width=1024):
     hour_height, label_column_pct = get_layout_config(screen_width)
@@ -273,17 +290,13 @@ def generate_day_view_html(events_df, clicked_date, get_color_fn, screen_width=1
 
         # Visible block
         event_blocks.append(
-            html.Div(
-                html.Span(row["EventName"], className="event-block-label"),
-                title=row["EventName"],
-                className="event-block",
-                style={
-                    "top": f"{top_px}px",
-                    "left": f"{left_pct}%",
-                    "width": f"{width_pct}%",
-                    "height": f"{height_px}px",
-                    "backgroundColor": color,
-                },
+            create_day_event_block(
+                row,
+                top_px=top_px,
+                height_px=height_px,
+                left_pct=left_pct,
+                width_pct=width_pct,
+                color=color,
             )
         )
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -37,6 +37,7 @@
   --color-border-primary: var(--color-primary-dark);
   --color-border-accent: var(--color-accent);
   --color-border-grid: #7F8BAA;
+  --color-border-grid-light: rgba(127, 139, 170, 0.3);
   /* Borders and shadows */
   --border-radius-lg: 0.625rem;
   --border-radius-sm: 0.3125rem;
@@ -350,6 +351,16 @@ h1,
   background-color: var(--color-background);
 }
 
+.hour-grid-line {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  border-top: var(--border-thin) solid var(--color-border-grid-light);
+  box-sizing: border-box;
+  pointer-events: none;
+  z-index: 2;
+}
+
 .event-label-title {
   font-size: var(--font-subtitle);
   font-weight: var(--font-weight-bold);
@@ -368,11 +379,19 @@ h1,
   align-items: start;
 }
 
+.day-modal-title {
+  font-size: var(--font-subtitle);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-accent);
+  margin-bottom: var(--padding-small);
+  text-align: center;
+}
+
 .event-label strong {
   color: var(--color-accent);
 }
 
-.event-block {
+.event-block-day {
   position: absolute;
   border: var(--border-thin);
   border-radius: var(--border-radius-sm);
@@ -381,6 +400,18 @@ h1,
   cursor: pointer;
   font-size: var(--font-small);
   font-weight: var(--font-weight-normal);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--padding-xxs);
+  overflow: hidden;
+}
+
+.event-block-day__label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--fg);
 }
 
 .no-events {
@@ -504,6 +535,18 @@ h1,
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+.day-click-area {
+  background: none;
+  border: none;
+  cursor: zoom-in;
+  z-index: 5;
+}
+
+.day-click-area:hover {
+  background-color: rgba(106, 90, 205, 0.1);
+  cursor: zoom-in;
 }
 
 /* 5. Left/Right overflow arrows */

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -168,7 +168,7 @@ h1,
     color: var(--color-accent);
 }
 
-.event-block {
+.event-block-day {
     position: absolute;
     border: var(--border-thin);
     border-radius: var(--border-radius-sm);
@@ -184,7 +184,7 @@ h1,
     overflow: hidden;
 }
 
-.event-block-label {
+.event-block-day__label {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- add a dedicated `day` event block component with unique styling
- update day modal to use the new component
- compile CSS for the new classes

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_686fade0e170832fb1cc172719638162