### PR TITLE
refactor: consolidate event logic

### DIFF
--- a/app_components/callbacks/events.py
+++ b/app_components/callbacks/events.py
@@ -1,20 +1,15 @@
 from datetime import datetime, timedelta
-from typing import Any, List
 
 import dash
 import pandas as pd
-from dash import ALL, Input, Output, State, html, no_update
+from dash import ALL, Input, Output, State, no_update
 from pytz import timezone
 
 from utils.colors import get_color
-from utils.data_parsing import (
-    annotate_events_with_flags,
-    assign_event_rows,
-    filter_week_events,
-)
+from utils.data_parsing import prepare_week_events
 
 from ..plotting import generate_day_view_html
-from ..utils import offer_type_emoji
+from ..utils import build_event_info_rows
 
 PDT = timezone("America/Los_Angeles")
 
@@ -120,11 +115,7 @@ def register_callbacks(app, df):
             current_sunday = today - timedelta(days=(today.weekday() + 1) % 7)
             week_start = current_sunday + timedelta(weeks=week_offset)
 
-            df_week = filter_week_events(df, week_start, week_start + timedelta(days=7))
-            df_annot = annotate_events_with_flags(
-                df_week, week_start, week_start + timedelta(days=7)
-            )
-            df_assigned = assign_event_rows(df_annot, week_start)
+            df_assigned = prepare_week_events(df, week_start)
             df_assigned = df_assigned.drop_duplicates("orig_index")
             df_assigned = df_assigned.set_index("orig_index")
 
@@ -143,47 +134,7 @@ def register_callbacks(app, df):
             if isinstance(row, pd.DataFrame):
                 row = row.iloc[0]
 
-            rows: List[Any] = []
-            emoji = offer_type_emoji(row.get("OfferType", ""))
-            rows.append(
-                html.H2(f"{emoji} Promo Info {emoji}", className="event-label-title")
-            )
-
-            for label in [
-                "EventName",
-                "Casino",
-                "OfferType",
-                "StartDate",
-                "EndDate",
-                "Offer",
-            ]:
-                if label in row:
-                    display_label = {
-                        "EventName": "Name of Event",
-                        "StartDate": "Start of Event",
-                        "EndDate": "End of Event",
-                        "OfferType": "Offer Type",
-                    }.get(label, label)
-
-                    value = row[label]
-
-                    if label in ["StartDate", "EndDate"]:
-                        try:
-                            value = pd.to_datetime(value).strftime(
-                                "%b %d, %Y @ %I:%M %p"
-                            )
-                        except Exception:
-                            pass
-
-                    rows.append(
-                        html.Div(
-                            [
-                                html.Strong(f"{display_label}: "),
-                                html.Span(value),
-                            ],
-                            className="event-label",
-                        )
-                    )
+            rows = build_event_info_rows(row.items())
             return ({}, "modal show", rows, 0, {"display": "none"}, "", "")
 
         if isinstance(triggered_id, dict) and triggered_id.get("type") == "day-column":
@@ -264,47 +215,7 @@ def register_callbacks(app, df):
                     "Offer",
                 ]
             ):
-                emoji = offer_type_emoji(data.get("OfferType", ""))
-                rows = [
-                    html.H2(
-                        f"{emoji} Promo Info {emoji}", className="event-label-title"
-                    )
-                ]
-                for label in [
-                    "EventName",
-                    "Casino",
-                    "OfferType",
-                    "StartDate",
-                    "EndDate",
-                    "Offer",
-                ]:
-                    if label in data:
-                        display_label = {
-                            "EventName": "Name of Event",
-                            "StartDate": "Start of Event",
-                            "EndDate": "End of Event",
-                            "OfferType": "Offer Type",
-                        }.get(label, label)
-
-                        value = data[label]
-
-                        if label in ["StartDate", "EndDate"]:
-                            try:
-                                value = pd.to_datetime(value).strftime(
-                                    "%b %d, %Y @ %I:%M %p"
-                                )
-                            except Exception:
-                                pass
-
-                        rows.append(
-                            html.Div(
-                                [
-                                    html.Strong(f"{display_label}: "),
-                                    html.Span(value),
-                                ],
-                                className="event-label",
-                            )
-                        )
+                rows = build_event_info_rows(data.items())
                 return ({}, "modal show", rows, 0, {"display": "none"}, "", "")
 
         raise dash.exceptions.PreventUpdate

--- a/app_components/plotting.py
+++ b/app_components/plotting.py
@@ -1,8 +1,11 @@
 from datetime import timedelta
+from math import floor
 
 import pandas as pd
 import plotly.graph_objs as go
 from dash import dcc, html
+
+from utils.colors import get_color
 
 from .utils import PDT, offer_type_emoji, trim_label
 

--- a/app_components/utils.py
+++ b/app_components/utils.py
@@ -1,9 +1,10 @@
 import json
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Tuple
+from typing import Any, Iterable, Tuple
 
 import pandas as pd
+from dash import html
 from pytz import timezone
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
@@ -86,3 +87,43 @@ def filter_long_spanning_events(
     return events_df[
         (events_df["StartDate"] < week_start) & (events_df["EndDate"] > week_end)
     ].copy()
+
+
+def build_event_info_rows(data: Iterable[tuple[str, Any]]) -> list:
+    """Return HTML rows for event details given a ``data`` iterable."""
+
+    mapping = dict(data)
+    emoji = offer_type_emoji(mapping.get("OfferType", ""))
+    rows = [html.H2(f"{emoji} Promo Info {emoji}", className="event-label-title")]
+
+    for label in [
+        "EventName",
+        "Casino",
+        "OfferType",
+        "StartDate",
+        "EndDate",
+        "Offer",
+    ]:
+        if label in mapping:
+            display_label = {
+                "EventName": "Name of Event",
+                "StartDate": "Start of Event",
+                "EndDate": "End of Event",
+                "OfferType": "Offer Type",
+            }.get(label, label)
+
+            value = mapping[label]
+            if label in ["StartDate", "EndDate"]:
+                try:
+                    value = pd.to_datetime(value).strftime("%b %d, %Y @ %I:%M %p")
+                except Exception:
+                    pass
+
+            rows.append(
+                html.Div(
+                    [html.Strong(f"{display_label}: "), html.Span(value)],
+                    className="event-label",
+                )
+            )
+
+    return rows

--- a/app_components/week_grid_layout.py
+++ b/app_components/week_grid_layout.py
@@ -2,11 +2,7 @@ import pandas as pd
 from dash import html
 
 from utils.colors import get_color
-from utils.data_parsing import (
-    annotate_events_with_flags,
-    assign_event_rows,
-    filter_week_events,
-)
+from utils.data_parsing import prepare_week_events
 
 from .utils import get_week_range, trim_label
 
@@ -95,10 +91,8 @@ def render_week_grid(clicked_date, df, screen_width=1024):
     # Wrap the labels so the entire row can be sticky
     header_row = html.Div(day_labels, className="day-label-wrapper")
 
-    # Filer/annotate/assign events
-    df_week = filter_week_events(df, week_start, week_end)
-    df_annot = annotate_events_with_flags(df_week, week_start, week_end)
-    df_assigned = assign_event_rows(df_annot, week_start)
+    # Filter and annotate events for the week
+    df_assigned = prepare_week_events(df, week_start)
 
     # Duplicate events that continue into Sunday so a matching block renders in
     # the Sunday column. The duplicated block retains the original ``orig_index``

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -3,11 +3,7 @@ from datetime import datetime, timedelta
 import pandas as pd
 import plotly.graph_objs as go
 
-from app_components.plotting import (
-    annotate_events_with_flags,
-    build_weekly_figure,
-    filter_week_events,
-)
+from app_components.plotting import build_weekly_figure
 from app_components.utils import PDT
 from utils.data_parsing import annotate_events_with_flags, filter_week_events
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,6 +3,7 @@ from .data_parsing import (
     annotate_events_with_flags,
     assign_event_rows,
     filter_week_events,
+    prepare_week_events,
 )
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "annotate_events_with_flags",
     "filter_week_events",
     "assign_event_rows",
+    "prepare_week_events",
 ]

--- a/utils/data_parsing.py
+++ b/utils/data_parsing.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from datetime import timedelta
 from math import floor
 
 
@@ -94,3 +95,12 @@ def assign_event_rows(events_df, week_start):
         current_row = max(row_nums, default=current_row) + 1
 
     return events_df
+
+
+def prepare_week_events(events_df, week_start):
+    """Return events filtered and annotated for a single week."""
+
+    week_end = week_start + timedelta(days=7)
+    week_events = filter_week_events(events_df, week_start, week_end)
+    annotated = annotate_events_with_flags(week_events, week_start, week_end)
+    return assign_event_rows(annotated, week_start)


### PR DESCRIPTION
## Summary
- simplify modal callback by extracting repeated event info rows
- centralize weekly event preparation logic
- fix plotting imports and update tests

Closes #100

## Testing
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_687730928658832fad50dea8ea1aaac9