### PR TITLE
refactor: clarify unused callback params

### DIFF
--- a/app_components/callbacks/events.py
+++ b/app_components/callbacks/events.py
@@ -57,14 +57,19 @@ def register_callbacks(app, df):
     )
     def show_event_modal(
         day_click,
-        close_clicks,
-        timer_tick,
-        close_day_clicks,
-        grid_clicks,
-        day_column_clicks,
+        _close_clicks,
+        _timer_tick,
+        _close_day_clicks,
+        _grid_clicks,
+        _day_column_clicks,
         week_offset,
         screen_width,
     ):
+        """Handle modal open and close events.
+
+        Unused parameters prefixed with an underscore are included solely so the
+        callback fires when those inputs change.
+        """
         ctx = dash.callback_context
         triggered_id = ctx.triggered_id
 

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -48,7 +48,7 @@ def register_callbacks(app, df):
         Input("next-button", "n_clicks"),
         State("week-offset", "data"),
     )
-    def update_week_offset(prev_clicks, next_clicks, current_offset):
+    def update_week_offset(_prev_clicks, _next_clicks, current_offset):
         ctx = dash.callback_context
         desired_offset = current_offset
 


### PR DESCRIPTION
## Summary
- add clarification docstring for `show_event_modal`
- rename unused callback parameters with underscore to document they trigger updates

## Testing
- `scripts/test.sh`

Closes #101

------
https://chatgpt.com/codex/tasks/task_e_6877377891f0832fb63688d27fbcbe5d