### PR TITLE
fix: handle DST when loading event data

### DIFF
--- a/app_components/data.py
+++ b/app_components/data.py
@@ -1,7 +1,9 @@
 import json
+from datetime import timedelta
 from pathlib import Path
 
 import pandas as pd
+from pytz import AmbiguousTimeError, NonExistentTimeError
 
 from .utils import PDT
 
@@ -58,12 +60,22 @@ def load_event_data(csv_path: str = "data/casino_events.csv") -> pd.DataFrame:
     """Load event data from ``csv_path`` with timezone normalized to PDT."""
     df = pd.read_csv(csv_path)
 
+    def _to_pdt(ts: pd.Timestamp) -> pd.Timestamp:
+        """Return ``ts`` localized to PDT handling DST edges."""
+        if pd.isna(ts):
+            return ts
+        if ts.tzinfo is None:
+            try:
+                return PDT.localize(ts, is_dst=None)
+            except AmbiguousTimeError:
+                return PDT.localize(ts, is_dst=False)
+            except NonExistentTimeError:
+                return PDT.localize(ts + timedelta(hours=1))
+        return ts.astimezone(PDT)
+
     for col in ["StartDate", "EndDate"]:
         df[col] = pd.to_datetime(df[col], errors="coerce")
-        if df[col].dt.tz is None:
-            df[col] = df[col].dt.tz_localize(PDT)
-        else:
-            df[col] = df[col].dt.tz_convert(PDT)
+        df[col] = df[col].map(_to_pdt)
 
     df["OfferType"] = df.apply(
         lambda row: categorize_offer_type_updated(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -38,3 +38,23 @@ def test_load_event_data_localizes_dates(tmp_path: Path):
     assert result["StartDate"].dt.tz is not None
     assert result["StartDate"].dt.tz.zone == PDT.zone
     assert result.loc[0, "OfferType"] == "Free-Play"
+
+
+def test_load_event_data_handles_dst(tmp_path: Path):
+    csv_path = tmp_path / "dst.csv"
+    df = pd.DataFrame(
+        {
+            "EventName": ["DST Event"],
+            "Casino": ["Test Casino"],
+            "Location": ["Test"],
+            "Offer": [""],
+            "StartDate": ["3/9/2025 1:30"],
+            "EndDate": ["3/9/2025 3:30"],
+        }
+    )
+    df.to_csv(csv_path, index=False)
+
+    result = load_event_data(csv_path)
+
+    delta = result.loc[0, "EndDate"] - result.loc[0, "StartDate"]
+    assert delta.total_seconds() == 3600


### PR DESCRIPTION
## Summary
- adjust event localization to handle DST transitions
- cover DST boundary in tests

## Testing
- `scripts/test.sh`

Closes #109

------
https://chatgpt.com/codex/tasks/task_e_68786c2523a4832f88d1ba8eb019a732