### PR TITLE
refactor: store datetimes in UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ but are not tested.
 - Modal windows for detailed event and day information
 - CSS grid layout for weekly view
 - Responsive design for desktop, tablet and mobile
-- Time zone normalized to Pacific Time (PDT)
+- Times stored in UTC and displayed in Pacific Time (PDT)
 - Toggle to show ongoing events that span the week
 - Auto-categorizes offers into Giveaway, Free-Play, Point-Based, Hospitality-Rewards and Special-Events
 - SCSS styles compiled with Sass

--- a/app_components/callbacks/events.py
+++ b/app_components/callbacks/events.py
@@ -10,7 +10,7 @@ from utils.colors import get_color
 from utils.data_parsing import prepare_week_events
 
 from ..plotting import generate_day_view_html
-from ..utils import build_event_info_rows
+from ..utils import build_event_info_rows, to_naive_utc
 
 PDT = timezone("America/Los_Angeles")
 
@@ -120,7 +120,7 @@ def register_callbacks(app, df) -> None:
                     no_update,
                 )
 
-            today = datetime.now(PDT)
+            today = datetime.utcnow()
             current_sunday = today - timedelta(days=(today.weekday() + 1) % 7)
             week_start = current_sunday + timedelta(weeks=week_offset)
 
@@ -163,7 +163,7 @@ def register_callbacks(app, df) -> None:
                     no_update,
                 )
 
-            clicked_date = PDT.localize(datetime.strptime(date_str, "%Y-%m-%d"))
+            clicked_date = to_naive_utc(datetime.strptime(date_str, "%Y-%m-%d"))
             content = generate_day_view_html(df, clicked_date, get_color, screen_width)
 
             return (
@@ -195,7 +195,7 @@ def register_callbacks(app, df) -> None:
                         no_update,
                     )
 
-                today = datetime.now(PDT)
+                today = datetime.utcnow()
                 current_sunday = today - timedelta(days=(today.weekday() + 1) % 7)
                 week_start = current_sunday + timedelta(weeks=week_offset)
                 clicked_date = week_start + timedelta(days=day_index)

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -6,7 +6,7 @@ import dash
 from dash import Input, Output, State, html
 from pytz import timezone
 
-from ..utils import filter_long_spanning_events
+from ..utils import filter_long_spanning_events, to_pdt
 from ..week_grid_layout import render_week_grid
 
 PDT = timezone("America/Los_Angeles")
@@ -34,12 +34,14 @@ def register_callbacks(app, df) -> None:
     @app.callback(Output("week-label", "children"), Input("week-offset", "data"))
     def update_week_label(week_offset: int) -> str:
         """Return a label for the currently selected week."""
-        today = datetime.now(PDT)
+        today = datetime.utcnow()
         current_sunday = today - timedelta(days=(today.weekday() + 1) % 7)
         week_start = current_sunday + timedelta(weeks=week_offset)
+        week_start_pdt = to_pdt(week_start)
+        week_end_pdt = week_start_pdt + timedelta(days=6)
         return (
-            f"Events for the Week of {week_start.strftime('%B %d')} - "
-            f"{(week_start + timedelta(days=6)).strftime('%B %d, %Y')}"
+            f"Events for the Week of {week_start_pdt.strftime('%B %d')} - "
+            f"{week_end_pdt.strftime('%B %d, %Y')}"
         )
 
     @app.callback(
@@ -66,7 +68,7 @@ def register_callbacks(app, df) -> None:
             desired_offset += 1
 
         desired_offset = max(-6, desired_offset)
-        today = datetime.now(PDT)
+        today = datetime.utcnow()
         current_sunday = today - timedelta(days=(today.weekday() + 1) % 7)
 
         next_week_offset = desired_offset + 1
@@ -101,7 +103,7 @@ def register_callbacks(app, df) -> None:
         screen_width: int,
     ) -> Tuple[html.Div, str, str, dict[str, Any]]:
         """Render a single week of events and overflow list."""
-        today = datetime.now(PDT)
+        today = datetime.utcnow()
         current_sunday = today - timedelta(days=(today.weekday() + 1) % 7)
         week_start = current_sunday + timedelta(weeks=week_offset)
 
@@ -111,8 +113,10 @@ def register_callbacks(app, df) -> None:
         overflow_df = filter_long_spanning_events(df, week_start, week_end)
 
         if not overflow_df.empty:
+            week_start_pdt = to_pdt(week_start)
+            week_end_pdt = to_pdt(week_end)
             overflow_toggle = html.Button(
-                f"\U0001f300 Show Ongoing Events for {week_start.strftime('%b %d')} - {week_end.strftime('%b %d')}",
+                f"\U0001f300 Show Ongoing Events for {week_start_pdt.strftime('%b %d')} - {week_end_pdt.strftime('%b %d')}",
                 id="overflow-toggle",
                 n_clicks=0,
                 className="overflow-toggle",
@@ -129,7 +133,9 @@ def register_callbacks(app, df) -> None:
                     html.Ul(
                         [
                             html.Li(
-                                f"{row['EventName']} ({row['Casino']}) - {row['StartDate'].strftime('%b %d')} to {row['EndDate'].strftime('%b %d')}",
+                                f"{row['EventName']} ({row['Casino']}) - "
+                                f"{to_pdt(row['StartDate']).strftime('%b %d')} to "
+                                f"{to_pdt(row['EndDate']).strftime('%b %d')}",
                                 style={"color": "#00008B"},
                             )
                             for _, row in overflow_df.iterrows()

--- a/app_components/data.py
+++ b/app_components/data.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from pathlib import Path
 
 import pandas as pd
-from pytz import AmbiguousTimeError, NonExistentTimeError
+from pytz import UTC, AmbiguousTimeError, NonExistentTimeError
 
 from .utils import PDT
 
@@ -57,25 +57,27 @@ def categorize_offer_type_updated(event_name: str | None, offer: str | None) -> 
 
 
 def load_event_data(csv_path: str = "data/casino_events.csv") -> pd.DataFrame:
-    """Load event data from ``csv_path`` with timezone normalized to PDT."""
+    """Load event data from ``csv_path`` with times stored as naive UTC."""
     df = pd.read_csv(csv_path)
 
-    def _to_pdt(ts: pd.Timestamp) -> pd.Timestamp:
-        """Return ``ts`` localized to PDT handling DST edges."""
+    def _to_naive_utc(ts: pd.Timestamp) -> pd.Timestamp:
+        """Return ``ts`` converted to naive UTC handling DST edges."""
         if pd.isna(ts):
             return ts
         if ts.tzinfo is None:
             try:
-                return PDT.localize(ts, is_dst=None)
+                localized = PDT.localize(ts, is_dst=None)
             except AmbiguousTimeError:
-                return PDT.localize(ts, is_dst=False)
+                localized = PDT.localize(ts, is_dst=False)
             except NonExistentTimeError:
-                return PDT.localize(ts + timedelta(hours=1))
-        return ts.astimezone(PDT)
+                localized = PDT.localize(ts + timedelta(hours=1))
+        else:
+            localized = ts.astimezone(PDT)
+        return localized.astimezone(UTC).replace(tzinfo=None)
 
     for col in ["StartDate", "EndDate"]:
         df[col] = pd.to_datetime(df[col], errors="coerce")
-        df[col] = df[col].map(_to_pdt)
+        df[col] = df[col].map(_to_naive_utc)
 
     df["OfferType"] = df.apply(
         lambda row: categorize_offer_type_updated(

--- a/app_components/plotting.py
+++ b/app_components/plotting.py
@@ -8,7 +8,7 @@ from dash import dcc, html
 
 from utils.colors import get_color
 
-from .utils import PDT, offer_type_emoji, trim_label
+from .utils import offer_type_emoji, to_pdt, trim_label
 
 
 # Layout config shared across functions
@@ -32,18 +32,16 @@ def generate_day_view_html(
     hour_height, label_column_pct = get_layout_config(screen_width)
 
     # Normalize clicked_date
-    day_start = clicked_date.astimezone(PDT).replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
+    day_start = to_pdt(clicked_date).replace(hour=0, minute=0, second=0, microsecond=0)
     day_end = day_start + timedelta(days=1)
 
     # Filter events strictly within the day
     events = events_df.copy()
-    events["StartDate"] = pd.to_datetime(events["StartDate"]).dt.tz_convert(PDT)
-    events["EndDate"] = pd.to_datetime(events["EndDate"]).dt.tz_convert(PDT)
+    events["StartDate"] = pd.to_datetime(events["StartDate"]).map(to_pdt)
+    events["EndDate"] = pd.to_datetime(events["EndDate"]).map(to_pdt)
     events = events[(events["StartDate"] >= day_start) & (events["EndDate"] <= day_end)]
 
-    day_label = clicked_date.strftime("%A, %B %d")
+    day_label = to_pdt(clicked_date).strftime("%A, %B %d")
     header_text = f"Events for {day_label}"
 
     if events.empty:

--- a/app_components/utils.py
+++ b/app_components/utils.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, Tuple
 
 import pandas as pd
 from dash import html
-from pytz import timezone
+from pytz import UTC, timezone
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 with open(DATA_DIR / "offer_type_emojis.json", encoding="utf-8") as f:
@@ -19,6 +19,25 @@ def offer_type_emoji(offer_type: str) -> str:
 
 
 PDT = timezone("America/Los_Angeles")
+
+
+def to_naive_utc(dt: datetime) -> datetime:
+    """Return ``dt`` converted to naive UTC."""
+
+    tz = dt.tzinfo or PDT
+    if dt.tzinfo is None:
+        localized = tz.localize(dt)
+    else:
+        localized = dt.astimezone(tz)
+    return localized.astimezone(UTC).replace(tzinfo=None)
+
+
+def to_pdt(dt: datetime) -> datetime:
+    """Return ``dt`` converted from naive UTC to aware PDT."""
+
+    if dt.tzinfo is None:
+        dt = UTC.localize(dt)
+    return dt.astimezone(PDT)
 
 
 def get_week_range(clicked_date: datetime) -> Tuple[datetime, datetime]:
@@ -37,10 +56,13 @@ def get_week_range(clicked_date: datetime) -> Tuple[datetime, datetime]:
     else:
         localized = clicked_date.astimezone(tz)
 
-    week_start = (localized - timedelta(days=(localized.weekday() + 1) % 7)).replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
-    week_end = week_start + timedelta(days=7)
+    week_start_local = (
+        localized - timedelta(days=(localized.weekday() + 1) % 7)
+    ).replace(hour=0, minute=0, second=0, microsecond=0)
+    week_end_local = week_start_local + timedelta(days=7)
+
+    week_start = week_start_local.astimezone(UTC).replace(tzinfo=None)
+    week_end = week_end_local.astimezone(UTC).replace(tzinfo=None)
 
     return week_start, week_end
 
@@ -115,7 +137,8 @@ def build_event_info_rows(data: Iterable[tuple[str, Any]]) -> list:
             value = mapping[label]
             if label in ["StartDate", "EndDate"]:
                 try:
-                    value = pd.to_datetime(value).strftime("%b %d, %Y @ %I:%M %p")
+                    ts = pd.to_datetime(value)
+                    value = to_pdt(ts).strftime("%b %d, %Y @ %I:%M %p")
                 except Exception:
                     pass
 

--- a/tests/test_breakpoints.py
+++ b/tests/test_breakpoints.py
@@ -1,11 +1,11 @@
 from datetime import datetime, timedelta
 
-from app_components.utils import PDT
+from app_components.utils import to_naive_utc
 from app_components.week_grid_layout import _build_block
 
 
 def test_build_block_breakpoints():
-    week_start = PDT.localize(datetime(2025, 7, 6))
+    week_start = to_naive_utc(datetime(2025, 7, 6))
     week_end = week_start + timedelta(days=7)
     row = {
         "EventName": "This is a very long event name for testing breakpoints",

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -5,7 +5,7 @@ from dash import Dash
 from freezegun import freeze_time
 
 from app_components.callbacks import register_callbacks
-from app_components.utils import PDT
+from app_components.utils import to_naive_utc
 
 
 class DummyCtx:
@@ -23,14 +23,14 @@ def test_update_week_offset_next(monkeypatch):
             "Location": ["L", "L", "L"],
             "Offer": ["", "", ""],
             "StartDate": [
-                PDT.localize(datetime(2025, 4, 14)),
-                PDT.localize(datetime(2025, 4, 21)),
-                PDT.localize(datetime(2025, 4, 28)),
+                to_naive_utc(datetime(2025, 4, 14)),
+                to_naive_utc(datetime(2025, 4, 21)),
+                to_naive_utc(datetime(2025, 4, 28)),
             ],
             "EndDate": [
-                PDT.localize(datetime(2025, 4, 14, 1)),
-                PDT.localize(datetime(2025, 4, 21, 1)),
-                PDT.localize(datetime(2025, 4, 28, 1)),
+                to_naive_utc(datetime(2025, 4, 14, 1)),
+                to_naive_utc(datetime(2025, 4, 21, 1)),
+                to_naive_utc(datetime(2025, 4, 28, 1)),
             ],
         }
     )
@@ -57,8 +57,8 @@ def test_update_week_offset_no_next(monkeypatch):
             "Casino": ["C"],
             "Location": ["L"],
             "Offer": [""],
-            "StartDate": [PDT.localize(datetime(2025, 4, 14))],
-            "EndDate": [PDT.localize(datetime(2025, 4, 14, 1))],
+            "StartDate": [to_naive_utc(datetime(2025, 4, 14))],
+            "EndDate": [to_naive_utc(datetime(2025, 4, 14, 1))],
         }
     )
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import pandas as pd
 
 from app_components.data import categorize_offer_type_updated, load_event_data
-from app_components.utils import PDT
 
 
 def test_categorize_offer_type_updated_basic():
@@ -35,8 +34,7 @@ def test_load_event_data_localizes_dates(tmp_path: Path):
 
     result = load_event_data(csv_path)
 
-    assert result["StartDate"].dt.tz is not None
-    assert result["StartDate"].dt.tz.zone == PDT.zone
+    assert result["StartDate"].dt.tz is None
     assert result.loc[0, "OfferType"] == "Free-Play"
 
 

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -2,11 +2,11 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 
-from app_components.utils import PDT, filter_long_spanning_events
+from app_components.utils import filter_long_spanning_events, to_naive_utc
 
 
 def test_filter_long_spanning_events():
-    week_start = PDT.localize(datetime(2025, 7, 6))
+    week_start = to_naive_utc(datetime(2025, 7, 6))
     week_end = week_start + timedelta(days=7)
     df = pd.DataFrame(
         {

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -4,12 +4,12 @@ import pandas as pd
 import plotly.graph_objs as go
 
 from app_components.plotting import build_weekly_figure
-from app_components.utils import PDT
+from app_components.utils import to_naive_utc
 from utils.data_parsing import annotate_events_with_flags, filter_week_events
 
 
 def test_build_weekly_figure_structure():
-    week_start = PDT.localize(datetime(2025, 4, 13))
+    week_start = to_naive_utc(datetime(2025, 4, 13))
     df = pd.DataFrame(
         {
             "EventName": ["Event"],

--- a/tests/test_text_overflow.py
+++ b/tests/test_text_overflow.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from app_components.utils import PDT
+from app_components.utils import to_naive_utc
 from app_components.week_grid_layout import _build_block
 
 LONG_TEXT = "This is a very long event name for overflow testing"
@@ -23,7 +23,7 @@ COLORS = {"ilani": {"bg": "#fff", "text": "#000"}}
 
 
 def test_build_block_adds_ellipsis_on_narrow_screen():
-    week_start = PDT.localize(datetime(2025, 7, 6))
+    week_start = to_naive_utc(datetime(2025, 7, 6))
     week_end = week_start + timedelta(days=7)
     row = _row(week_start + timedelta(days=1), week_start + timedelta(days=2))
 
@@ -32,7 +32,7 @@ def test_build_block_adds_ellipsis_on_narrow_screen():
 
 
 def test_build_block_uses_emoji_when_too_small():
-    week_start = PDT.localize(datetime(2025, 7, 6))
+    week_start = to_naive_utc(datetime(2025, 7, 6))
     week_end = week_start + timedelta(days=7)
     row = _row(week_start + timedelta(days=1), week_start + timedelta(days=2))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,22 +1,28 @@
 from datetime import datetime
 
-from app_components.utils import PDT, get_week_range, offer_type_emoji, trim_label
+from app_components.utils import (
+    PDT,
+    get_week_range,
+    offer_type_emoji,
+    to_pdt,
+    trim_label,
+)
 
 
 def test_get_week_range_returns_sunday_bounds():
-    tz = PDT
-    dt = tz.localize(datetime(2025, 4, 16, 15, 0))
+    dt = PDT.localize(datetime(2025, 4, 16, 15, 0))
     start, end = get_week_range(dt)
-    assert start.weekday() == 6
-    assert start.hour == 0
-    assert start.tzinfo.zone == tz.zone
+    start_pdt = to_pdt(start)
+    assert start_pdt.weekday() == 6
+    assert start_pdt.hour == 0
+    assert start.tzinfo is None
     assert (end - start).days == 7
 
 
 def test_get_week_range_handles_naive_datetime():
     dt = datetime(2025, 4, 16, 15, 0)
     start, _ = get_week_range(dt)
-    assert start.tzinfo.zone == PDT.zone
+    assert start.tzinfo is None
 
 
 def test_trim_label_truncates_and_emojis():


### PR DESCRIPTION
## Summary
- normalize event data to UTC
- convert times to PDT when rendering
- update week label and overflow text helpers
- adjust tests for new timezone handling

Closes #110

## Testing
- `bash scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68786e926cdc832f9f5587340ffb6333