### PR TITLE
test: expand boundary coverage

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -56,3 +56,23 @@ def test_load_event_data_handles_dst(tmp_path: Path):
 
     delta = result.loc[0, "EndDate"] - result.loc[0, "StartDate"]
     assert delta.total_seconds() == 3600
+
+
+def test_load_event_data_handles_dst_fall(tmp_path: Path):
+    csv_path = tmp_path / "dst_fall.csv"
+    df = pd.DataFrame(
+        {
+            "EventName": ["DST Fall"],
+            "Casino": ["Test Casino"],
+            "Location": ["Test"],
+            "Offer": [""],
+            "StartDate": ["11/2/2025 0:30"],
+            "EndDate": ["11/2/2025 2:30"],
+        }
+    )
+    df.to_csv(csv_path, index=False)
+
+    result = load_event_data(csv_path)
+
+    delta = result.loc[0, "EndDate"] - result.loc[0, "StartDate"]
+    assert delta.total_seconds() == 10800

--- a/tests/test_week_events.py
+++ b/tests/test_week_events.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from app_components.utils import to_naive_utc
+from utils.data_parsing import prepare_week_events
+
+
+def test_prepare_week_events_flags_boundary_events():
+    week_start = to_naive_utc(datetime(2025, 7, 6))
+    df = pd.DataFrame(
+        {
+            "EventName": ["Left", "Right", "Full"],
+            "Casino": ["ilani"] * 3,
+            "StartDate": [
+                week_start - timedelta(days=1),
+                week_start + timedelta(days=5),
+                week_start - timedelta(days=1),
+            ],
+            "EndDate": [
+                week_start + timedelta(hours=2),
+                week_start + timedelta(days=7, hours=2),
+                week_start + timedelta(days=8),
+            ],
+        }
+    )
+
+    result = prepare_week_events(df, week_start)
+
+    names = list(result["EventName"])
+    assert names == ["Left", "Right"]
+
+    left = result[result["EventName"] == "Left"].iloc[0]
+    right = result[result["EventName"] == "Right"].iloc[0]
+
+    assert left["has_left_arrow"] and not left["has_right_arrow"]
+    assert right["has_right_arrow"] and not right["has_left_arrow"]


### PR DESCRIPTION
## Summary
- expand DST tests to handle the fall transition
- add week-event boundary test for multi-day spans

## Testing
- `scripts/test.sh`

Closes #111

------
https://chatgpt.com/codex/tasks/task_e_68787604a270832fb379d25bef230116