### PR TITLE
test: parametrize suites across casinos and offers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,25 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # Ensure app modules are importable
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+CASINOS = ["ilani", "Lucky Eagle Casino"]
+OFFER_TYPES = ["Giveaway", "Free-Play"]
+
+
+@pytest.fixture(params=CASINOS)
+def casino(request):
+    """Return a casino name for parametrized tests."""
+
+    return request.param
+
+
+@pytest.fixture(params=OFFER_TYPES)
+def offer_type(request):
+    """Return an offer type for parametrized tests."""
+
+    return request.param

--- a/tests/test_breakpoints.py
+++ b/tests/test_breakpoints.py
@@ -1,22 +1,25 @@
 from datetime import datetime, timedelta
 
+import pytest
+
 from app_components.utils import to_naive_utc
 from app_components.week_grid_layout import _build_block
 
 
-def test_build_block_breakpoints():
+@pytest.mark.usefixtures("casino")
+def test_build_block_breakpoints(casino):
     week_start = to_naive_utc(datetime(2025, 7, 6))
     week_end = week_start + timedelta(days=7)
     row = {
         "EventName": "This is a very long event name for testing breakpoints",
-        "Casino": "ilani",
+        "Casino": casino,
         "row_num": 0,
         "StartDate": week_start + timedelta(days=1),
         "EndDate": week_start + timedelta(days=3),
         "has_left_arrow": False,
         "has_right_arrow": False,
     }
-    colors = {"ilani": {"bg": "#fff", "text": "#000"}}
+    colors = {casino: {"bg": "#fff", "text": "#000"}}
 
     mobile_text, _, _ = _build_block(row, week_start, week_end, 375, colors)
     tablet_text, _, _ = _build_block(row, week_start, week_end, 650, colors)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pandas as pd
+import pytest
 from dash import Dash
 from freezegun import freeze_time
 
@@ -15,11 +16,12 @@ class DummyCtx:
 
 
 @freeze_time("2025-04-15")
-def test_update_week_offset_next(monkeypatch):
+@pytest.mark.usefixtures("casino")
+def test_update_week_offset_next(monkeypatch, casino):
     df = pd.DataFrame(
         {
             "EventName": ["E1", "E2", "E3"],
-            "Casino": ["C", "C", "C"],
+            "Casino": [casino, casino, casino],
             "Location": ["L", "L", "L"],
             "Offer": ["", "", ""],
             "StartDate": [
@@ -50,11 +52,12 @@ def test_update_week_offset_next(monkeypatch):
 
 
 @freeze_time("2025-04-15")
-def test_update_week_offset_no_next(monkeypatch):
+@pytest.mark.usefixtures("casino")
+def test_update_week_offset_no_next(monkeypatch, casino):
     df = pd.DataFrame(
         {
             "EventName": ["E1"],
-            "Casino": ["C"],
+            "Casino": [casino],
             "Location": ["L"],
             "Offer": [""],
             "StartDate": [to_naive_utc(datetime(2025, 4, 14))],
@@ -74,7 +77,8 @@ def test_update_week_offset_no_next(monkeypatch):
     assert next_disabled
 
 
-def test_toggle_overflow(monkeypatch):
+@pytest.mark.usefixtures("casino")
+def test_toggle_overflow(monkeypatch, casino):
     df = pd.DataFrame()
     app = Dash(__name__)
     register_callbacks(app, df)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,29 +1,37 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from app_components.data import categorize_offer_type_updated, load_event_data
 
 
-def test_categorize_offer_type_updated_basic():
-    assert categorize_offer_type_updated("Car Giveaway", "") == "Giveaway"
-    assert categorize_offer_type_updated("", "free play bonus") == "Free-Play"
-    assert categorize_offer_type_updated("Points Multiplier", "") == "Point-Based"
-    assert categorize_offer_type_updated("Hotel Stay", "") == "Hospitality-Rewards"
-    assert categorize_offer_type_updated("Tournament", "") == "Special-Events"
-    assert categorize_offer_type_updated("Generic Promo", "") == "Offer"
+@pytest.mark.parametrize(
+    "event_name,offer,expected",
+    [
+        ("Car Giveaway", "", "Giveaway"),
+        ("", "free play bonus", "Free-Play"),
+        ("Points Multiplier", "", "Point-Based"),
+        ("Hotel Stay", "", "Hospitality-Rewards"),
+        ("Tournament", "", "Special-Events"),
+        ("Generic Promo", "", "Offer"),
+    ],
+)
+def test_categorize_offer_type_updated_basic(event_name, offer, expected):
+    assert categorize_offer_type_updated(event_name, offer) == expected
 
 
 def test_categorize_offer_type_handles_missing():
     assert categorize_offer_type_updated(None, None) == "Offer"
 
 
-def test_load_event_data_localizes_dates(tmp_path: Path):
+@pytest.mark.usefixtures("casino")
+def test_load_event_data_localizes_dates(tmp_path: Path, casino):
     csv_path = tmp_path / "sample.csv"
     df = pd.DataFrame(
         {
             "EventName": ["Test Event"],
-            "Casino": ["Test Casino"],
+            "Casino": [casino],
             "Location": ["Test"],
             "Offer": ["free play"],
             "StartDate": ["1/1/2025 10:00"],
@@ -38,12 +46,13 @@ def test_load_event_data_localizes_dates(tmp_path: Path):
     assert result.loc[0, "OfferType"] == "Free-Play"
 
 
-def test_load_event_data_handles_dst(tmp_path: Path):
+@pytest.mark.usefixtures("casino")
+def test_load_event_data_handles_dst(tmp_path: Path, casino):
     csv_path = tmp_path / "dst.csv"
     df = pd.DataFrame(
         {
             "EventName": ["DST Event"],
-            "Casino": ["Test Casino"],
+            "Casino": [casino],
             "Location": ["Test"],
             "Offer": [""],
             "StartDate": ["3/9/2025 1:30"],
@@ -58,12 +67,13 @@ def test_load_event_data_handles_dst(tmp_path: Path):
     assert delta.total_seconds() == 3600
 
 
-def test_load_event_data_handles_dst_fall(tmp_path: Path):
+@pytest.mark.usefixtures("casino")
+def test_load_event_data_handles_dst_fall(tmp_path: Path, casino):
     csv_path = tmp_path / "dst_fall.csv"
     df = pd.DataFrame(
         {
             "EventName": ["DST Fall"],
-            "Casino": ["Test Casino"],
+            "Casino": [casino],
             "Location": ["Test"],
             "Offer": [""],
             "StartDate": ["11/2/2025 0:30"],

--- a/tests/test_modals.py
+++ b/tests/test_modals.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pandas as pd
+import pytest
 from dash import Dash
 
 from app_components.callbacks import register_callbacks
@@ -14,11 +15,11 @@ class DummyCtx:
         self.triggered = [{"prop_id": f"{triggered_id}.n_clicks", "value": 1}]
 
 
-def _create_app():
+def _create_app(casino: str):
     df = pd.DataFrame(
         {
             "EventName": ["Weekend Bash"],
-            "Casino": ["ilani"],
+            "Casino": [casino],
             "Location": [""],
             "Offer": [""],
             "StartDate": [to_naive_utc(datetime(2025, 7, 12, 10))],
@@ -35,8 +36,9 @@ def _create_app():
     return func
 
 
-def test_show_event_modal_handles_duplicate(monkeypatch):
-    func = _create_app()
+@pytest.mark.usefixtures("casino")
+def test_show_event_modal_handles_duplicate(monkeypatch, casino):
+    func = _create_app(casino)
 
     def fake_prepare(events_df, week_start):
         return data_parsing.prepare_week_events(
@@ -57,8 +59,9 @@ def test_show_event_modal_handles_duplicate(monkeypatch):
     assert result[4] == {"display": "none"}
 
 
-def test_show_event_modal_close(monkeypatch):
-    func = _create_app()
+@pytest.mark.usefixtures("casino")
+def test_show_event_modal_close(monkeypatch, casino):
+    func = _create_app(casino)
     monkeypatch.setattr("dash.callback_context", DummyCtx("close-modal"), raising=False)
 
     result = func(None, 1, 0, 0, [0], [0], 0, 1024)

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -1,17 +1,19 @@
 from datetime import datetime, timedelta
 
 import pandas as pd
+import pytest
 
 from app_components.utils import filter_long_spanning_events, to_naive_utc
 
 
-def test_filter_long_spanning_events():
+@pytest.mark.usefixtures("casino")
+def test_filter_long_spanning_events(casino):
     week_start = to_naive_utc(datetime(2025, 7, 6))
     week_end = week_start + timedelta(days=7)
     df = pd.DataFrame(
         {
             "EventName": ["A", "B", "C", "D"],
-            "Casino": ["C"] * 4,
+            "Casino": [casino] * 4,
             "StartDate": [
                 week_start - timedelta(days=1),
                 week_start - timedelta(days=1),

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -2,19 +2,21 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 import plotly.graph_objs as go
+import pytest
 
 from app_components.plotting import build_weekly_figure
 from app_components.utils import to_naive_utc
 from utils.data_parsing import annotate_events_with_flags, filter_week_events
 
 
-def test_build_weekly_figure_structure():
+@pytest.mark.usefixtures("casino", "offer_type")
+def test_build_weekly_figure_structure(casino, offer_type):
     week_start = to_naive_utc(datetime(2025, 4, 13))
     df = pd.DataFrame(
         {
             "EventName": ["Event"],
-            "Casino": ["ilani"],
-            "OfferType": ["Giveaway"],
+            "Casino": [casino],
+            "OfferType": [offer_type],
             "StartDate": [week_start + timedelta(days=1, hours=2)],
             "EndDate": [week_start + timedelta(days=1, hours=4)],
         }

--- a/tests/test_text_overflow.py
+++ b/tests/test_text_overflow.py
@@ -1,16 +1,18 @@
 from datetime import datetime, timedelta
 
-from app_components.utils import to_naive_utc
+import pytest
+
+from app_components.utils import offer_type_emoji, to_naive_utc
 from app_components.week_grid_layout import _build_block
 
 LONG_TEXT = "This is a very long event name for overflow testing"
 
 
-def _row(start, end):
+def _row(start, end, casino: str, offer: str) -> dict:
     return {
         "EventName": LONG_TEXT,
-        "OfferType": "Giveaway",
-        "Casino": "ilani",
+        "OfferType": offer,
+        "Casino": casino,
         "row_num": 0,
         "StartDate": start,
         "EndDate": end,
@@ -19,22 +21,37 @@ def _row(start, end):
     }
 
 
-COLORS = {"ilani": {"bg": "#fff", "text": "#000"}}
+COLORS = {
+    "ilani": {"bg": "#fff", "text": "#000"},
+    "Lucky Eagle Casino": {"bg": "#fff", "text": "#000"},
+}
 
 
-def test_build_block_adds_ellipsis_on_narrow_screen():
+@pytest.mark.usefixtures("offer_type", "casino")
+def test_build_block_adds_ellipsis_on_narrow_screen(casino, offer_type):
     week_start = to_naive_utc(datetime(2025, 7, 6))
     week_end = week_start + timedelta(days=7)
-    row = _row(week_start + timedelta(days=1), week_start + timedelta(days=2))
+    row = _row(
+        week_start + timedelta(days=1),
+        week_start + timedelta(days=2),
+        casino,
+        offer_type,
+    )
 
     text, _, _ = _build_block(row, week_start, week_end, 375, COLORS)
     assert text.endswith("...")
 
 
-def test_build_block_uses_emoji_when_too_small():
+@pytest.mark.usefixtures("offer_type", "casino")
+def test_build_block_uses_emoji_when_too_small(casino, offer_type):
     week_start = to_naive_utc(datetime(2025, 7, 6))
     week_end = week_start + timedelta(days=7)
-    row = _row(week_start + timedelta(days=1), week_start + timedelta(days=2))
+    row = _row(
+        week_start + timedelta(days=1),
+        week_start + timedelta(days=2),
+        casino,
+        offer_type,
+    )
 
     text, _, _ = _build_block(row, week_start, week_end, 100, COLORS)
-    assert text == "🎁🎰"
+    assert text == offer_type_emoji(offer_type)

--- a/tests/test_week_events.py
+++ b/tests/test_week_events.py
@@ -1,17 +1,19 @@
 from datetime import datetime, timedelta
 
 import pandas as pd
+import pytest
 
 from app_components.utils import to_naive_utc
 from utils.data_parsing import prepare_week_events
 
 
-def test_prepare_week_events_flags_boundary_events():
+@pytest.mark.usefixtures("casino")
+def test_prepare_week_events_flags_boundary_events(casino):
     week_start = to_naive_utc(datetime(2025, 7, 6))
     df = pd.DataFrame(
         {
             "EventName": ["Left", "Right", "Full"],
-            "Casino": ["ilani"] * 3,
+            "Casino": [casino] * 3,
             "StartDate": [
                 week_start - timedelta(days=1),
                 week_start + timedelta(days=5),


### PR DESCRIPTION
## Summary
- parametrize tests using pytest fixtures for casino names and offer types
- update tests to use new fixtures and dynamic expectations

Closes #113

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68787a655b48832f8d4bfd0f8d8b4039