### PR TITLE
chore: run optional linters in test script

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,6 +16,15 @@ fi
 if command -v flake8 >/dev/null 2>&1; then
     flake8 .
 fi
+if command -v mypy >/dev/null 2>&1; then
+    mypy .
+fi
+if command -v bandit >/dev/null 2>&1; then
+    bandit -r .
+fi
+if command -v pydocstyle >/dev/null 2>&1; then
+    pydocstyle .
+fi
 
 # Run test suite
 pytest -q


### PR DESCRIPTION
## Summary
- include `mypy`, `bandit` and `pydocstyle` in `scripts/test.sh` when available

Closes #114

## Testing
- `scripts/test.sh` *(fails: mypy reports missing stubs)*

------
https://chatgpt.com/codex/tasks/task_e_687885f05bb0832f8c6ba0b6f3f0bab6