### PR TITLE
chore: add stylelint script to tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ source .venv/bin/activate  # use .\.venv\Scripts\activate on Windows
 scripts/setup.sh                 # install Python and Node dependencies
 npm install
 npm run build:css
+npm run lint:css
 pip install -r requirements.txt
 pre-commit install
 pre-commit run --all-files

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:css": "sass --no-source-map assets/style.scss assets/style.generated.css",
     "watch:css": "sass --no-source-map --watch assets/style.scss assets/style.css",
-    "lint:css": "stylelint \"assets/**/*.scss\""
+    "lint:css": "stylelint 'assets/**/*.scss'"
   },
   "devDependencies": {
     "@stylistic/stylelint-plugin": "^3.1.3",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,6 +25,9 @@ fi
 if command -v pydocstyle >/dev/null 2>&1; then
     pydocstyle .
 fi
+if command -v npm >/dev/null 2>&1; then
+    npm run lint:css
+fi
 
 # Run test suite
 pytest -q


### PR DESCRIPTION
## Summary
- update `package.json` with a `lint:css` task
- call the CSS linter from `scripts/test.sh`
- document `npm run lint:css` usage in the README

## Testing
- `./scripts/test.sh`

Closes #117 

------
https://chatgpt.com/codex/tasks/task_e_687898718c78832fb7583cbbbf5d3a55