### PR TITLE
fix: add coverage plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ beautifulsoup4==4.12.3
 freezegun==1.5.0
 # Dash testing utilities
 dash[testing]==3.1.1
+pytest-cov==5.0.0

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,5 +29,5 @@ if command -v npm >/dev/null 2>&1; then
     npm run lint:css
 fi
 
-# Run test suite
-pytest -q
+# Run test suite with coverage
+pytest --cov=app_components tests/ -q


### PR DESCRIPTION
## Summary
- install pytest-cov for coverage
- run pytest with coverage in `scripts/test.sh`

## Testing
- `pytest --cov=app_components tests/`
- `bash scripts/test.sh` *(fails: mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878a0833ae0832fad0cd396221dcd07