### PR TITLE
chore: align css build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,3 @@ dist/
 
 # Node dependencies
 node_modules/
-
-assets/style.generated.css
-
-.fake

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ python3 -m venv .venv
 source .venv/bin/activate  # use .\.venv\Scripts\activate on Windows
 scripts/setup.sh                 # install Python and Node dependencies
 npm install
-npm run build:css
+npm run build:css  # compiles assets/style.scss to assets/style.css
 npm run lint:css
 pip install -r requirements.txt
 pre-commit install

--- a/assets/styles/AGENTS.md
+++ b/assets/styles/AGENTS.md
@@ -1,14 +1,18 @@
 # AGENTS instructions for `assets/styles`
 
-SCSS partials in this folder are combined into `../style.scss` and compiled to `../style.css`.
+SCSS partials in this folder are combined into `../style.scss` and compiled to
+`../style.css`.
 
 - Use BEM-like class names and keep selectors narrow.
 - Place design tokens in `_variables.scss` and reusable code in `_mixins.scss`.
-- After editing SCSS files, regenerate `style.css` if the `sass` command is available:
+- After editing SCSS files, regenerate `style.css` using the unified script
+  (`npm run build:css`). It outputs the same file watched by `npm run watch:css`
+  and is used in deployment. If `sass` is installed globally you can also run it
+  directly:
 
   ```bash
   npm run build:css
-  npm run watch:css # optional for auto-rebuild
+  npm run watch:css   # optional for auto-rebuild
   sass ../style.scss ../style.css
   ```
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Dash casino event calendar assets",
   "private": true,
   "scripts": {
-    "build:css": "sass --no-source-map assets/style.scss assets/style.generated.css",
+    "build:css": "sass --no-source-map assets/style.scss assets/style.css",
     "watch:css": "sass --no-source-map --watch assets/style.scss assets/style.css",
     "lint:css": "stylelint 'assets/**/*.scss'"
   },


### PR DESCRIPTION
## Summary
- update CSS build target so build and watch scripts match
- stop ignoring style.generated.css and fix `.gitignore` end
- clarify unified build command in `assets/styles/AGENTS.md`
- note compiled CSS file in README

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_687b2265c348832f8cb6bac5d084766a