### PR TITLE
feat: add run script for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ scripts/test.sh                  # run linters and tests
 python app.py
 ```
 
+On Windows you can run everything from one command by executing `run.bat`
+in a Command Prompt or the VSCode terminal:
+
+```cmd
+run.bat
+```
+
 ## 🌍 Deployment
 
 Hosted at [https://casino-calendar.onrender.com](https://casino-calendar.onrender.com)

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,4 @@
+@echo off
+call setup.bat
+python app.py
+


### PR DESCRIPTION
## Summary
- add `run.bat` for running setup and launching the app on Windows
- update local running instructions in the README

## Testing
- `scripts/test.sh` *(fails: pytest: error: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_687b6baac958832fa395b4551386f220