### PR TITLE
fix: align week label with grid

### DIFF
--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -56,7 +56,7 @@ body {
 .week-chart-scroll {
     overflow-x: visible;
     /* scrolling handled by parent container */
-    padding: 0 var(--padding-small) calc(var(--padding-base) * 3 + var(--overflow-expand-max-height));
+    padding: 0 var(--padding-base) calc(var(--padding-base) * 3 + var(--overflow-expand-max-height));
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary
- match week grid scroll padding to base spacing for alignment

## Testing
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_687dcbf6f6a4832f992e0c94475c4b88