### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -129,11 +129,23 @@ def sticky_header(df):
                             "flex": "1",
                         },
                     ),
-                    html.Button(
-                        "🎰",
-                        id="next-button",
-                        n_clicks=0,
-                        className="emoji-button",
+                    html.Div(
+                        [
+                            html.Button(
+                                "🎰",
+                                id="next-button",
+                                n_clicks=0,
+                                className="emoji-button",
+                            ),
+                            html.Button(
+                                "🌙",
+                                id="theme-toggle",
+                                n_clicks=0,
+                                className="emoji-button",
+                                title="Toggle dark mode",
+                            ),
+                        ],
+                        style={"display": "flex", "gap": "0.5rem"},
                     ),
                 ],
                 style={

--- a/assets/base.css
+++ b/assets/base.css
@@ -117,3 +117,13 @@
 
 body {
   overflow: visible; }
+
+[data-theme="dark"] {
+  --color-background: #1e1e1e;
+  --color-primary-dark: #e0e0e0;
+  --color-border-primary: var(--color-primary-dark);
+  --color-border-grid: #555555;
+  --color-border-grid-light: rgba(127, 139, 170, 0.6);
+  --box-shadow-light: 0 -0.125rem 0.3125rem rgba(255, 255, 255, 0.2);
+  --box-shadow-modal: 0 0 1.25rem rgba(255, 255, 255, 0.25);
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -136,6 +136,17 @@ body {
   overflow: visible;
 }
 
+/* Dark theme overrides */
+[data-theme=dark] {
+  --color-background: #1e1e1e;
+  --color-primary-dark: #e0e0e0;
+  --color-border-primary: var(--color-primary-dark);
+  --color-border-grid: #555555;
+  --color-border-grid-light: rgba(127, 139, 170, 0.6);
+  --box-shadow-light: 0 -0.125rem 0.3125rem rgba(255, 255, 255, 0.2);
+  --box-shadow-modal: 0 0 1.25rem rgba(255, 255, 255, 0.25);
+}
+
 /* Application layout structure */
 /* Layout and Structure */
 html,
@@ -153,7 +164,7 @@ body {
 }
 .main-layout {
   font-family: "Segoe UI", sans-serif;
-  margin: 0 auto;
+  margin: 0 0.75px;
   padding-bottom: var(--padding-base);
 }
 
@@ -179,7 +190,7 @@ body {
 
 .calendar-scroll-body {
   overflow-y: auto;
-  padding: var(--padding-base);
+  padding: var(--padding-base) 0;
   box-sizing: border-box;
   background-color: var(--color-background);
 }
@@ -187,8 +198,9 @@ body {
 .week-chart-scroll {
   overflow-x: visible;
   /* scrolling handled by parent container */
-  padding: 0 var(--padding-small) calc(var(--padding-base) * 3 + var(--overflow-expand-max-height));
-  margin-bottom: 0;
+  box-sizing: border-box;
+  margin: 0 var(--padding-base);
+  padding: 0 0 calc(var(--padding-base) * 3 + var(--overflow-expand-max-height));
 }
 
 .week-label {
@@ -196,17 +208,27 @@ body {
   background-color: var(--color-background);
   box-shadow: var(--box-shadow-light);
   border-radius: var(--border-radius-sm);
-  z-index: 900;
+  box-sizing: border-box;
   text-align: center;
   font-size: var(--font-header);
   font-weight: var(--font-weight-bold);
-  padding: var(--padding-base);
-  margin-bottom: auto;
+  padding: var(--padding-base) 0;
+  margin: 0 var(--padding-base) var(--gap-legend);
 }
 
 @media (max-width: 480px), (max-width: 896px) and (orientation: landscape) {
   .week-label {
     font-size: var(--font-header);
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .week-chart-scroll {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .calendar-scroll-body {
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 .legend-container {
@@ -451,9 +473,9 @@ h1,
   background-color: var(--color-day-header-bg);
   border-top: var(--border-thin) solid var(--color-border-primary);
   border-bottom: var(--border-thin) solid var(--color-border-primary);
-  margin: 0 var(--padding-base) var(--header-gap);
-  margin-bottom: 0;
-  padding: 0 var(--padding-small);
+  box-sizing: border-box;
+  margin: 0 var(--padding-base);
+  padding: 0;
 }
 
 .day-label-grid {
@@ -623,6 +645,10 @@ h1,
 }
 
 @media (max-width: 480px), (max-width: 896px) and (orientation: landscape) {
+  .day-label-wrapper {
+    margin-left: 0;
+    margin-right: 0;
+  }
   .day-label-grid {
     font-size: var(--font-small);
   }

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -149,3 +149,14 @@
 body {
     overflow: visible;
 }
+
+/* Dark theme overrides */
+[data-theme="dark"] {
+    --color-background: #1e1e1e;
+    --color-primary-dark: #e0e0e0;
+    --color-border-primary: var(--color-primary-dark);
+    --color-border-grid: #555555;
+    --color-border-grid-light: rgba(127, 139, 170, 0.6);
+    --box-shadow-light: 0 -0.125rem 0.3125rem rgba(255, 255, 255, 0.2);
+    --box-shadow-modal: 0 0 1.25rem rgba(255, 255, 255, 0.25);
+}

--- a/assets/theme-toggle.js
+++ b/assets/theme-toggle.js
@@ -1,0 +1,30 @@
+(function () {
+  function applyTheme(saved) {
+    const root = document.documentElement;
+    if (saved === 'dark') {
+      root.setAttribute('data-theme', 'dark');
+      return true;
+    }
+    root.removeAttribute('data-theme');
+    return false;
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const button = document.getElementById('theme-toggle');
+    if (!button) return;
+    const isDark = applyTheme(localStorage.getItem('theme'));
+    button.textContent = isDark ? '☀️' : '🌙';
+    button.addEventListener('click', function () {
+      const currentlyDark = document.documentElement.getAttribute('data-theme') === 'dark';
+      if (currentlyDark) {
+        document.documentElement.removeAttribute('data-theme');
+        localStorage.setItem('theme', 'light');
+        button.textContent = '🌙';
+      } else {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        localStorage.setItem('theme', 'dark');
+        button.textContent = '☀️';
+      }
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- add dark mode CSS variables
- compile stylesheet with dark overrides
- add theme toggle button in sticky header
- store theme preference via small JS helper

## Testing
- `npm run lint:css`
- `pytest -q`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_687e3d024f00832fa430db7110f45889