### PR TITLE
refactor: show spanning events in day modal

### DIFF
--- a/app_components/plotting.py
+++ b/app_components/plotting.py
@@ -42,11 +42,11 @@ def generate_day_view_html(
     day_start = to_pdt(clicked_date).replace(hour=0, minute=0, second=0, microsecond=0)
     day_end = day_start + timedelta(days=1)
 
-    # Filter events strictly within the day
+    # Filter events overlapping the day
     events = events_df.copy()
     events["StartDate"] = pd.to_datetime(events["StartDate"]).map(to_pdt)
     events["EndDate"] = pd.to_datetime(events["EndDate"]).map(to_pdt)
-    events = events[(events["StartDate"] >= day_start) & (events["EndDate"] <= day_end)]
+    events = events[(events["EndDate"] > day_start) & (events["StartDate"] < day_end)]
 
     day_label = to_pdt(clicked_date).strftime("%A, %B %d")
     header_text = f"Events for {day_label}"
@@ -66,10 +66,12 @@ def generate_day_view_html(
         ]
 
     # Time math
+    events["adj_start"] = events["StartDate"].clip(lower=day_start, upper=day_end)
+    events["adj_end"] = events["EndDate"].clip(lower=day_start, upper=day_end)
     events["start_offset_min"] = (
-        events["StartDate"] - day_start
+        events["adj_start"] - day_start
     ).dt.total_seconds() / 60
-    events["end_offset_min"] = (events["EndDate"] - day_start).dt.total_seconds() / 60
+    events["end_offset_min"] = (events["adj_end"] - day_start).dt.total_seconds() / 60
     events["duration_min"] = events["end_offset_min"] - events["start_offset_min"]
     events = events.sort_values(by=["start_offset_min", "duration_min"])
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -108,3 +108,35 @@ def test_event_block_min_width_for_few_events():
     for div, name in zip(event_divs, df["EventName"]):
         expected_width = f"{len(name) + 2}ch"
         assert div.style.get("minWidth") == expected_width
+
+
+def test_day_view_includes_overlapping_events():
+    sunday = to_naive_utc(datetime(2025, 7, 13))
+    df = pd.DataFrame(
+        {
+            "EventName": ["Span1", "Span2"],
+            "Casino": ["ilani", "ilani"],
+            "OfferType": ["", ""],
+            "Offer": ["", ""],
+            "StartDate": [
+                sunday - timedelta(hours=2),
+                sunday + timedelta(hours=22),
+            ],
+            "EndDate": [
+                sunday + timedelta(days=1, hours=1),
+                sunday + timedelta(days=1, hours=2),
+            ],
+        }
+    )
+
+    sun_result = generate_day_view_html(df, sunday, get_color, 1024)
+    mon_result = generate_day_view_html(df, sunday + timedelta(days=1), get_color, 1024)
+
+    for result in (sun_result, mon_result):
+        grid_children = result[1].children
+        event_divs = [
+            c
+            for c in grid_children
+            if getattr(c, "className", "") and "event-block-day" in c.className
+        ]
+        assert len(event_divs) == 2


### PR DESCRIPTION
## Summary
- include events that overlap the day in day modal view
- clamp event positions to current day
- cover new logic with tests

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889f5c29ba4832f812c42930f29713c