### PR TITLE
feat: expand day modal height and sticky hour labels

### DIFF
--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -137,7 +137,7 @@ h1,
 }
 
 .hour-label {
-    position: absolute;
+    position: sticky;
     left: 0;
     font-size: var(--font-small);
     color: var(--color-accent);

--- a/assets/styles/_modal.scss
+++ b/assets/styles/_modal.scss
@@ -114,13 +114,13 @@
     width: auto;
     min-width: var(--day-modal-min-width);
     max-width: 90vw;
-    max-height: min(var(--day-modal-max-height), 90vh);
+    max-height: none;
     font-size: clamp(var(--font-small), 2vw, var(--font-base));
 }
 
 #day-modal-body {
     overflow-x: auto;
-    overflow-y: auto;
+    overflow-y: visible;
     padding: var(--padding-small);
     font-size: inherit;
 }
@@ -222,7 +222,7 @@
     }
 
     #day-modal-body {
-        max-height: var(--modal-max-height);
+        max-height: none;
     }
 }
 
@@ -235,11 +235,11 @@
         width: var(--modal-width-mobile) !important;
         max-width: var(--modal-width-mobile) !important;
         min-width: var(--modal-width-mobile);
-        max-height: var(--modal-max-height-mobile);
+        max-height: none;
     }
 
     #day-modal-body {
-        max-height: var(--modal-max-height-mobile);
+        max-height: none;
         font-size: var(--font-small);
     }
 }


### PR DESCRIPTION
## Summary
- allow day modal to expand without vertical scroll
- keep hour labels visible during horizontal scroll

## Testing
- `scripts/test.sh` *(fails: pytest, black, mypy, and isort not available)*

------
https://chatgpt.com/codex/tasks/task_e_688adbadbe38832f89eeefa13c90505d