### PR TITLE
fix: align day modal events within grid

### DIFF
--- a/app_components/plotting.py
+++ b/app_components/plotting.py
@@ -141,23 +141,36 @@ def generate_day_view_html(
     events["duration_min"] = events["end_offset_min"] - events["start_offset_min"]
     events = events.sort_values(by=["start_offset_min", "duration_min"])
 
-    # Assign tracks dynamically to avoid overlap
-    tracks = []
-    track_assignments = []
+    # Ensure a minimum visual height and use it for track calculations
+    min_block_px = 16
+    min_block_min = min_block_px / hour_height * 60
+    events["visual_end_offset_min"] = events["end_offset_min"].where(
+        events["duration_min"] >= min_block_min,
+        events["start_offset_min"] + min_block_min,
+    )
+    events["visual_end_offset_min"] = events["visual_end_offset_min"].clip(
+        upper=24 * 60
+    )
+    events["visual_duration_min"] = (
+        events["visual_end_offset_min"] - events["start_offset_min"]
+    )
+
+    # Assign tracks dynamically to avoid overlap using visual duration
+    tracks: list[list[tuple[float, float]]] = []
+    track_assignments: list[int] = []
 
     for _, event in events.iterrows():
         placed = False
+        start = event["start_offset_min"]
+        end = event["visual_end_offset_min"]
         for i, track in enumerate(tracks):
-            if all(
-                event["start_offset_min"] >= t[1] or event["end_offset_min"] <= t[0]
-                for t in track
-            ):
-                track.append((event["start_offset_min"], event["end_offset_min"]))
+            if all(start >= t[1] or end <= t[0] for t in track):
+                track.append((start, end))
                 track_assignments.append(i)
                 placed = True
                 break
         if not placed:
-            tracks.append([(event["start_offset_min"], event["end_offset_min"])])
+            tracks.append([(start, end)])
             track_assignments.append(len(tracks) - 1)
 
     events["overlap_index"] = track_assignments
@@ -179,10 +192,17 @@ def generate_day_view_html(
     width_pct = (100 - label_column_pct) / n_tracks
 
     color_map = get_color_fn()
-    hour_blocks = []
-    hour_lines = []
-    event_blocks = []
-    click_markers = []
+    hour_blocks: list[html.Div] = []
+    hour_lines: list[html.Div] = []
+    event_blocks: list[html.Div] = []
+    click_markers: list[go.Scatter] = []
+
+    track_width_pct = width_pct * 0.9  # leave small margin within track
+    max_track_width = f"{track_width_pct}%"
+    # Approximate track width in rem for width comparisons
+    track_width_rem = grid_min_width * track_width_pct / 100
+    CHAR_REM = 0.55
+    total_height_px = 24 * hour_height
 
     for hour in range(24):
         top_px = hour * hour_height
@@ -219,7 +239,10 @@ def generate_day_view_html(
         )  # Event blocks + invisible click markers
     for _, row in events.iterrows():
         top_px = row["start_offset_min"] / 60 * hour_height
-        height_px = max(16, row["duration_min"] / 60 * hour_height)
+        height_px = row["visual_duration_min"] / 60 * hour_height
+        height_px = max(16, height_px)
+        if top_px + height_px > total_height_px:
+            height_px = total_height_px - top_px
         # Position blocks using proper track-based layout to prevent overlap
         left_pct = label_column_pct + row["overlap_index"] * width_pct
 
@@ -267,10 +290,6 @@ def generate_day_view_html(
         event_name = str(row["EventName"])
         casino_name = str(row["Casino"])
 
-        # Calculate maximum width based on track allocation (leaving small margin)
-        track_width_pct = width_pct * 0.9  # Use 90% of track to leave margin
-        max_track_width = f"{track_width_pct}%"
-
         # Build the style dictionary with base properties
         style_dict = {
             "top": f"{top_px}px",
@@ -281,31 +300,41 @@ def generate_day_view_html(
         }
 
         if short_span:
-            # For short events, use character-based width when there are few events
-            if len(events) < 5:  # Few events - use character-based width
-                char_width = f"{len(event_name) + 2}ch"
-                style_dict["width"] = "auto"
-                style_dict["minWidth"] = char_width
-                style_dict["maxWidth"] = min(char_width, max_track_width)
+            if len(events) < 5:
+                char_len = len(event_name) + 2
+                char_width_rem = char_len * CHAR_REM
+                if char_width_rem <= track_width_rem:
+                    char_width = f"{char_len}ch"
+                    style_dict["width"] = "auto"
+                    style_dict["minWidth"] = char_width
+                    style_dict["maxWidth"] = char_width
+                else:
+                    style_dict["width"] = max_track_width
+                    style_dict["minWidth"] = max_track_width
+                    style_dict["maxWidth"] = max_track_width
             else:
-                # Many events - use minimal width based on emoji
                 style_dict["width"] = "auto"
-                style_dict["minWidth"] = "2.5rem"
-                style_dict["maxWidth"] = min(
-                    "3rem", max_track_width
-                )  # Constrain to track
+                if track_width_rem < 2.5:
+                    style_dict["minWidth"] = max_track_width
+                    style_dict["maxWidth"] = max_track_width
+                    style_dict["width"] = max_track_width
+                else:
+                    style_dict["minWidth"] = "2.5rem"
+                    style_dict["maxWidth"] = (
+                        max_track_width if track_width_rem < 3 else "3rem"
+                    )
         else:
-            # For longer events, use auto width with both character and track constraints
-            char_min = f"{min(len(event_name), len(casino_name))}ch"
-            char_max = (
-                f"{max(len(event_name), len(casino_name)) + 1}ch"  # Reduced padding
-            )
-
-            style_dict["width"] = "auto"
-            style_dict["minWidth"] = char_min
-            style_dict["maxWidth"] = (
-                f"min({char_max}, {max_track_width})"  # Respect track bounds
-            )
+            char_min_len = min(len(event_name), len(casino_name))
+            char_max_len = max(len(event_name), len(casino_name)) + 1
+            char_max_rem = char_max_len * CHAR_REM
+            if char_max_rem <= track_width_rem:
+                style_dict["width"] = "auto"
+                style_dict["minWidth"] = f"{char_min_len}ch"
+                style_dict["maxWidth"] = f"{char_max_len}ch"
+            else:
+                style_dict["width"] = max_track_width
+                style_dict["minWidth"] = max_track_width
+                style_dict["maxWidth"] = max_track_width
 
         block_kwargs: dict[str, Any] = dict(
             title=row["EventName"],
@@ -352,14 +381,14 @@ def generate_day_view_html(
             layout=go.Layout(
                 clickmode="event+select",
                 xaxis=dict(visible=False, range=[0, 1], fixedrange=True),
-                yaxis=dict(visible=False, range=[0, 24 * hour_height], fixedrange=True),
+                yaxis=dict(visible=False, range=[0, total_height_px], fixedrange=True),
                 margin=dict(l=0, r=0, t=0, b=0),
-                height=24 * hour_height,
+                height=total_height_px,
                 plot_bgcolor="rgba(0,0,0,0)",
                 paper_bgcolor="rgba(0,0,0,0)",
             ),
         ),
-        style={"height": f"{24 * hour_height}px"},
+        style={"height": f"{total_height_px}px"},
         config={"displayModeBar": False},
     )
 
@@ -375,7 +404,7 @@ def generate_day_view_html(
             children=hour_blocks + hour_lines + event_blocks + [click_graph],
             className="day-grid",
             style={
-                "height": f"{24 * hour_height}px",
+                "height": f"{total_height_px}px",
                 "minWidth": f"{grid_min_width}rem",
             },
         ),

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -3,13 +3,13 @@ from datetime import datetime, timedelta
 import pandas as pd
 import plotly.graph_objs as go
 import pytest
-
 from app_components.plotting import (
     DAY_MODAL_LABEL_REM,
     DAY_MODAL_TRACK_REM,
     DAY_MODAL_WIDE_REM,
     build_weekly_figure,
     generate_day_view_html,
+    get_layout_config,
 )
 from app_components.utils import to_naive_utc
 from utils.colors import get_color
@@ -107,7 +107,11 @@ def test_event_block_min_width_for_few_events():
     assert len(event_divs) == 2
     for div, name in zip(event_divs, df["EventName"]):
         expected_width = f"{len(name) + 2}ch"
-        assert div.style.get("minWidth") == expected_width
+        min_width = div.style.get("minWidth")
+        if min_width.endswith("ch"):
+            assert min_width == expected_width
+        else:
+            assert min_width.endswith("%")
 
 
 def test_day_view_includes_overlapping_events():
@@ -140,3 +144,44 @@ def test_day_view_includes_overlapping_events():
             if getattr(c, "className", "") and "event-block-day" in c.className
         ]
         assert len(event_divs) == 2
+
+
+def test_short_events_near_midnight_do_not_overlap_or_overflow():
+    clicked = to_naive_utc(datetime(2025, 8, 5))
+    df = pd.DataFrame(
+        {
+            "EventName": ["Late1", "Late2"],
+            "Casino": ["ilani", "ilani"],
+            "OfferType": ["", ""],
+            "Offer": ["", ""],
+            "StartDate": [
+                clicked.replace(hour=6, minute=50) + timedelta(days=1),
+                clicked.replace(hour=6, minute=55) + timedelta(days=1),
+            ],
+            "EndDate": [
+                clicked.replace(hour=6, minute=55) + timedelta(days=1),
+                clicked.replace(hour=7) + timedelta(days=1),
+            ],
+        }
+    )
+
+    result = generate_day_view_html(df, clicked, get_color, 1024)
+    grid_children = result[1].children
+    event_divs = [
+        c
+        for c in grid_children
+        if getattr(c, "className", "") and "event-block-day" in c.className
+    ]
+    assert len(event_divs) == 2
+
+    hour_height, _ = get_layout_config(1024)
+    total_height = 24 * hour_height
+    lefts = set()
+    for div in event_divs:
+        top = float(div.style.get("top", "0px").rstrip("px"))
+        height = float(div.style.get("height", "0px").rstrip("px"))
+        assert top >= 0
+        assert top + height <= total_height
+        lefts.add(div.style.get("left"))
+
+    assert len(lefts) == 2, "Events should occupy separate tracks"


### PR DESCRIPTION
## Summary
- enforce minimum duration and width bounds for day modal events
- clamp event block height to grid limits
- test short near-midnight events stay within hourly grid

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black app_components/plotting.py tests/test_plotting.py`
- `isort --settings-path config/.isort.cfg tests/test_plotting.py`
- `flake8 app_components/plotting.py tests/test_plotting.py` *(fails: command not found)*
- `pytest tests/test_plotting.py tests/test_day_modal_boundary_cases.py`


------
https://chatgpt.com/codex/tasks/task_e_6892e35c4bec832f8e028711adb57dfe