### PR TITLE
fix: lighten Muckleshoot text color in dark mode

### DIFF
--- a/app_components/plotting.py
+++ b/app_components/plotting.py
@@ -139,7 +139,11 @@ def generate_day_view_html(
     ).dt.total_seconds() / 60
     events["end_offset_min"] = (events["adj_end"] - day_start).dt.total_seconds() / 60
     events["duration_min"] = events["end_offset_min"] - events["start_offset_min"]
-    events = events.sort_values(by=["start_offset_min", "duration_min"])
+
+    # Sort events for display order: start time, then casino, then category (OfferType)
+    events = events.sort_values(
+        by=["start_offset_min", "Casino", "OfferType", "duration_min"]
+    )
 
     # Minimum block height: even extremely short events should remain
     # visible and clickable in the grid. ``min_block_px`` defines the

--- a/assets/base.css
+++ b/assets/base.css
@@ -132,7 +132,8 @@ body {
 
 [data-theme="dark"] {
     --color-background: #3c3c3c;
-    --color-primary-dark: #e0e0e0;
+    --color-primary-dark: #6a5acd;
+    --color-accent: #a78bfa;
     --color-border-primary: var(--color-primary-dark);
     --color-border-grid: #555555;
     --color-border-grid-light: rgba(127, 139, 170, 0.6);

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -236,6 +236,7 @@ h1,
 }
 
 [data-theme="dark"] {
+
     .legend-title,
     .hour-label,
     .event-label-title,
@@ -262,10 +263,14 @@ h1,
 
     .legend-text[style*="color:#1e1c29"],
     .legend-text[style*="color: #1e1c29"],
+    .legend-text[style*="color:rgb(30, 28, 41)"],
+    .legend-text[style*="color: rgb(30, 28, 41)"],
     .legend-text[style*="color:rgb(30 28 41)"],
     .legend-text[style*="color: rgb(30 28 41)"],
     #event-modal[style*="--bg:#1e1c29"] .event-label span,
     #event-modal[style*="--bg: #1e1c29"] .event-label span,
+    #event-modal[style*="--bg:rgb(30, 28, 41)"] .event-label span,
+    #event-modal[style*="--bg: rgb(30, 28, 41)"] .event-label span,
     #event-modal[style*="--bg:rgb(30 28 41)"] .event-label span,
     #event-modal[style*="--bg: rgb(30 28 41)"] .event-label span {
         color: rgb(166 161 193) !important;

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -268,7 +268,7 @@ h1,
     #event-modal[style*="--bg: #1e1c29"] .event-label span,
     #event-modal[style*="--bg:rgb(30 28 41)"] .event-label span,
     #event-modal[style*="--bg: rgb(30 28 41)"] .event-label span {
-        color: #4a4458 !important;
+        color: rgb(166 161 193) !important;
     }
 
     .overflow-toggle {

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -260,6 +260,17 @@ h1,
         }
     }
 
+    .legend-text[style*="color:#1e1c29"],
+    .legend-text[style*="color: #1e1c29"],
+    .legend-text[style*="color:rgb(30, 28, 41)"],
+    .legend-text[style*="color: rgb(30, 28, 41)"],
+    #event-modal[style*="--bg:#1e1c29"] .event-label span,
+    #event-modal[style*="--bg: #1e1c29"] .event-label span,
+    #event-modal[style*="--bg:rgb(30, 28, 41)"] .event-label span,
+    #event-modal[style*="--bg: rgb(30, 28, 41)"] .event-label span {
+        color: #4a4458 !important;
+    }
+
     .overflow-toggle {
         color: var(--color-primary-dark);
     }

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -262,12 +262,12 @@ h1,
 
     .legend-text[style*="color:#1e1c29"],
     .legend-text[style*="color: #1e1c29"],
-    .legend-text[style*="color:rgb(30, 28, 41)"],
-    .legend-text[style*="color: rgb(30, 28, 41)"],
+    .legend-text[style*="color:rgb(30 28 41)"],
+    .legend-text[style*="color: rgb(30 28 41)"],
     #event-modal[style*="--bg:#1e1c29"] .event-label span,
     #event-modal[style*="--bg: #1e1c29"] .event-label span,
-    #event-modal[style*="--bg:rgb(30, 28, 41)"] .event-label span,
-    #event-modal[style*="--bg: rgb(30, 28, 41)"] .event-label span {
+    #event-modal[style*="--bg:rgb(30 28 41)"] .event-label span,
+    #event-modal[style*="--bg: rgb(30 28 41)"] .event-label span {
         color: #4a4458 !important;
     }
 

--- a/tests/test_day_modal_sorting.py
+++ b/tests/test_day_modal_sorting.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Test the sorting logic for event blocks in the day modal.
+"""
+
+import pandas as pd
+from datetime import datetime
+from app_components.plotting import generate_day_view_html
+from utils.colors import get_color
+
+
+def test_day_modal_sorting():
+    """Test that event blocks are sorted by start time, casino, then category."""
+
+    # Create test data with events that should be sorted
+    clicked_date = datetime(2025, 8, 6, 0, 0, 0)  # naive UTC
+
+    test_events = pd.DataFrame(
+        [
+            {
+                "EventName": "Late Event",
+                "Casino": "Casino B",
+                "OfferType": "Giveaway",
+                "Offer": "Late event",
+                "StartDate": pd.Timestamp("2025-08-06 18:00:00"),  # 6 PM
+                "EndDate": pd.Timestamp("2025-08-06 20:00:00"),
+            },
+            {
+                "EventName": "Early Event Z Casino",
+                "Casino": "Casino Z",
+                "OfferType": "Free-Play",
+                "Offer": "Early event Z",
+                "StartDate": pd.Timestamp("2025-08-06 10:00:00"),  # 10 AM
+                "EndDate": pd.Timestamp("2025-08-06 12:00:00"),
+            },
+            {
+                "EventName": "Early Event A Casino",
+                "Casino": "Casino A",
+                "OfferType": "Point-Based",
+                "Offer": "Early event A",
+                "StartDate": pd.Timestamp("2025-08-06 10:00:00"),  # 10 AM (same time)
+                "EndDate": pd.Timestamp("2025-08-06 12:00:00"),
+            },
+            {
+                "EventName": "Same Casino Different Category 1",
+                "Casino": "Casino A",
+                "OfferType": "Free-Play",  # Should come before Point-Based alphabetically
+                "Offer": "Same casino category 1",
+                "StartDate": pd.Timestamp("2025-08-06 14:00:00"),  # 2 PM
+                "EndDate": pd.Timestamp("2025-08-06 16:00:00"),
+            },
+            {
+                "EventName": "Same Casino Different Category 2",
+                "Casino": "Casino A",
+                "OfferType": "Point-Based",  # Should come after Free-Play
+                "Offer": "Same casino category 2",
+                "StartDate": pd.Timestamp("2025-08-06 14:00:00"),  # 2 PM (same time)
+                "EndDate": pd.Timestamp("2025-08-06 16:00:00"),
+            },
+        ]
+    )
+
+    # Generate the day view
+    result = generate_day_view_html(test_events, clicked_date, get_color, 1024)
+
+    # Extract the grid container
+    assert len(result) >= 2, "Should have header and grid elements"
+    grid = result[1]
+
+    # Find all event blocks
+    assert hasattr(grid, "children") and grid.children, "Grid should have children"
+    event_blocks = [
+        child
+        for child in grid.children
+        if hasattr(child, "className")
+        and child.className
+        and "event-block-day" in child.className
+    ]
+
+    assert len(event_blocks) == 5, f"Expected 5 event blocks, got {len(event_blocks)}"
+
+    # Extract event titles to verify sorting order
+    event_titles = [block.title for block in event_blocks]
+
+    # Expected order:
+    # 1. 10 AM: Casino A (Point-Based) - "Early Event A Casino"
+    # 2. 10 AM: Casino Z (Free-Play) - "Early Event Z Casino"
+    # 3. 2 PM: Casino A (Free-Play) - "Same Casino Different Category 1"
+    # 4. 2 PM: Casino A (Point-Based) - "Same Casino Different Category 2"
+    # 5. 6 PM: Casino B (Giveaway) - "Late Event"
+    expected_order = [
+        "Early Event A Casino",  # 10 AM, Casino A, Point-Based
+        "Early Event Z Casino",  # 10 AM, Casino Z, Free-Play
+        "Same Casino Different Category 1",  # 2 PM, Casino A, Free-Play
+        "Same Casino Different Category 2",  # 2 PM, Casino A, Point-Based
+        "Late Event",  # 6 PM, Casino B, Giveaway
+    ]
+
+    print("Actual order:", event_titles)
+    print("Expected order:", expected_order)
+
+    assert (
+        event_titles == expected_order
+    ), f"Event order mismatch!\nActual: {event_titles}\nExpected: {expected_order}"
+
+    print("✅ Day modal sorting test passed!")
+
+
+if __name__ == "__main__":
+    test_day_modal_sorting()


### PR DESCRIPTION
## Summary
- adjust dark theme styles so Muckleshoot Casino text appears lighter in legend and event modal

## Testing
- `npm run lint:css` *(fails: rule-empty-line-before, media-feature-range-notation, color-function-notation, and other style issues)*
- `npm run build:css`
- `scripts/test.sh` *(fails: imports are incorrectly sorted and/or formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68965118a514832f8b81b0e9802b4f5d