### PR TITLE
feat: add staggered header animations

### DIFF
--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -282,6 +282,18 @@ def register_callbacks(app, df) -> None:
             setTimeout(function() {
                 const container = document.getElementById('week-chart-container');
                 if (!container) { return; }
+                const weekLabel = document.getElementById('week-label');
+                if (weekLabel) {
+                    weekLabel.classList.remove('slide-in');
+                    void weekLabel.offsetWidth;
+                    weekLabel.classList.add('slide-in');
+                }
+                const dayRow = document.getElementById('day-label-row');
+                if (dayRow) {
+                    dayRow.classList.remove('slide-in');
+                    void dayRow.offsetWidth;
+                    dayRow.classList.add('slide-in');
+                }
                 const chart = container.querySelector('.week-chart-scroll');
                 if (!chart) { return; }
                 chart.classList.remove('slide-in');

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -265,6 +265,7 @@ def register_callbacks(app, df) -> None:
             children=[grid, overflow_toggle, overflow_box],
             id=f"week-chart-{week_offset}",
             className="slide-init slide-in week-chart-scroll",
+            style={"--slide-distance": "6rem", "opacity": 0},
             **data_attr,
         )
 
@@ -279,27 +280,34 @@ def register_callbacks(app, df) -> None:
     app.clientside_callback(
         """
         function(refresh) {
-            setTimeout(function() {
+            requestAnimationFrame(() => {
                 const container = document.getElementById('week-chart-container');
                 if (!container) { return; }
+
                 const weekLabel = document.getElementById('week-label');
                 if (weekLabel) {
-                    weekLabel.classList.remove('slide-in');
+                    weekLabel.style.opacity = '1';
+                    weekLabel.classList.remove('slide-in', 'slide-init');
                     void weekLabel.offsetWidth;
-                    weekLabel.classList.add('slide-in');
+                    weekLabel.classList.add('slide-init', 'slide-in');
                 }
+
                 const dayRow = document.getElementById('day-label-row');
                 if (dayRow) {
-                    dayRow.classList.remove('slide-in');
+                    dayRow.style.opacity = '1';
+                    dayRow.classList.remove('slide-in', 'slide-init');
                     void dayRow.offsetWidth;
-                    dayRow.classList.add('slide-in');
+                    dayRow.classList.add('slide-init', 'slide-in');
                 }
+
                 const chart = container.querySelector('.week-chart-scroll');
-                if (!chart) { return; }
-                chart.classList.remove('slide-in');
-                void chart.offsetWidth;
-                chart.classList.add('slide-in');
-            }, 0);
+                if (chart) {
+                    chart.style.opacity = '1';
+                    chart.classList.remove('slide-in', 'slide-init');
+                    void chart.offsetWidth;
+                    chart.classList.add('slide-init', 'slide-in');
+                }
+            });
             return '';
         }
         """,

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -265,7 +265,6 @@ def register_callbacks(app, df) -> None:
             children=[grid, overflow_toggle, overflow_box],
             id=f"week-chart-{week_offset}",
             className="slide-init slide-in stagger-4 week-chart-scroll",
-            style={"--slide-distance": "8rem"},
             **data_attr,
         )
 

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -264,7 +264,7 @@ def register_callbacks(app, df) -> None:
         chart = html.Div(
             children=[grid, overflow_toggle, overflow_box],
             id=f"week-chart-{week_offset}",
-            className="slide-in week-chart-scroll",
+            className="slide-init slide-in week-chart-scroll",
             **data_attr,
         )
 

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -264,8 +264,8 @@ def register_callbacks(app, df) -> None:
         chart = html.Div(
             children=[grid, overflow_toggle, overflow_box],
             id=f"week-chart-{week_offset}",
-            className="slide-init slide-in week-chart-scroll",
-            style={"--slide-distance": "6rem", "opacity": 0},
+            className="slide-init slide-in stagger-4 week-chart-scroll",
+            style={"--slide-distance": "8rem"},
             **data_attr,
         )
 
@@ -286,7 +286,6 @@ def register_callbacks(app, df) -> None:
 
                 const weekLabel = document.getElementById('week-label');
                 if (weekLabel) {
-                    weekLabel.style.opacity = '1';
                     weekLabel.classList.remove('slide-in', 'slide-init');
                     void weekLabel.offsetWidth;
                     weekLabel.classList.add('slide-init', 'slide-in');
@@ -294,15 +293,20 @@ def register_callbacks(app, df) -> None:
 
                 const dayRow = document.getElementById('day-label-row');
                 if (dayRow) {
-                    dayRow.style.opacity = '1';
                     dayRow.classList.remove('slide-in', 'slide-init');
                     void dayRow.offsetWidth;
                     dayRow.classList.add('slide-init', 'slide-in');
                 }
 
+                const legendContainer = document.querySelector('.legend-container.slide-init');
+                if (legendContainer) {
+                    legendContainer.classList.remove('slide-in', 'slide-init');
+                    void legendContainer.offsetWidth;
+                    legendContainer.classList.add('slide-init', 'slide-in');
+                }
+
                 const chart = container.querySelector('.week-chart-scroll');
                 if (chart) {
-                    chart.style.opacity = '1';
                     chart.classList.remove('slide-in', 'slide-init');
                     void chart.offsetWidth;
                     chart.classList.add('slide-init', 'slide-in');

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -264,7 +264,7 @@ def register_callbacks(app, df) -> None:
         chart = html.Div(
             children=[grid, overflow_toggle, overflow_box],
             id=f"week-chart-{week_offset}",
-            className="slide-init slide-in stagger-3 week-chart-scroll",
+            className="slide-init slide-in stagger-4 week-chart-scroll",
             style={"--slide-distance": "8rem"},
             **data_attr,
         )

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -264,7 +264,7 @@ def register_callbacks(app, df) -> None:
         chart = html.Div(
             children=[grid, overflow_toggle, overflow_box],
             id=f"week-chart-{week_offset}",
-            className="slide-init slide-in stagger-4 week-chart-scroll",
+            className="week-chart-scroll",
             **data_attr,
         )
 

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -264,7 +264,7 @@ def register_callbacks(app, df) -> None:
         chart = html.Div(
             children=[grid, overflow_toggle, overflow_box],
             id=f"week-chart-{week_offset}",
-            className="slide-init slide-in stagger-4 week-chart-scroll",
+            className="slide-init slide-in stagger-3 week-chart-scroll",
             style={"--slide-distance": "8rem"},
             **data_attr,
         )
@@ -296,13 +296,6 @@ def register_callbacks(app, df) -> None:
                     dayRow.classList.remove('slide-in', 'slide-init');
                     void dayRow.offsetWidth;
                     dayRow.classList.add('slide-init', 'slide-in');
-                }
-
-                const legendContainer = document.querySelector('.legend-container.slide-init');
-                if (legendContainer) {
-                    legendContainer.classList.remove('slide-in', 'slide-init');
-                    void legendContainer.offsetWidth;
-                    legendContainer.classList.add('slide-init', 'slide-in');
                 }
 
                 const chart = container.querySelector('.week-chart-scroll');

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -139,7 +139,7 @@ def sticky_header(df):
             # Navigation & Legend
             html.Div(
                 id="header-container",
-                className="legend-container slide-in stagger-3",
+                className="legend-container",
                 children=[
                     html.Button(
                         "🎲",
@@ -154,7 +154,10 @@ def sticky_header(df):
                                 "Casino Legend:",
                                 className="legend-title legend-gap",
                             ),
-                            html.Div(create_legend(df), className="legend-container"),
+                            html.Div(
+                                create_legend(df),
+                                className="legend-container slide-init slide-in stagger-3",
+                            ),
                             # Hotel booking link that appears when a casino is selected
                             html.Div(
                                 id="hotel-booking-container",
@@ -186,20 +189,20 @@ def sticky_header(df):
                     "display": "flex",
                     "justifyContent": "space-between",
                     "paddingBottom": "10px",
-                    "--slide-distance": "1rem",
+                    "--slide-distance": "2rem",
                 },
             ),
             # Week Label and dynamic day headers
             html.Div(
                 id="week-label",
-                className="week-label slide-in stagger-1",
-                style={"--slide-distance": "1rem"},
+                className="week-label slide-init slide-in stagger-1",
+                style={"--slide-distance": "2rem"},
                 children="",
             ),
             html.Div(
                 id="day-label-row",
-                className="day-label-wrapper slide-in stagger-2",
-                style={"--slide-distance": "1rem"},
+                className="day-label-wrapper slide-init slide-in stagger-2",
+                style={"--slide-distance": "2rem"},
             ),
         ],
         className="sticky-header",

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -157,7 +157,6 @@ def sticky_header(df):
                             html.Div(
                                 create_legend(df),
                                 className="legend-container slide-init slide-in stagger-1",
-                                style={"--slide-distance": "4rem"},
                             ),
                             # Hotel booking link that appears when a casino is selected
                             html.Div(
@@ -197,13 +196,11 @@ def sticky_header(df):
             html.Div(
                 id="week-label",
                 className="week-label slide-init slide-in stagger-2",
-                style={"--slide-distance": "8rem"},
                 children="",
             ),
             html.Div(
                 id="day-label-row",
                 className="day-label-wrapper slide-init slide-in stagger-3",
-                style={"--slide-distance": "8rem"},
             ),
         ],
         className="sticky-header",

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -156,7 +156,7 @@ def sticky_header(df):
                             ),
                             html.Div(
                                 create_legend(df),
-                                className="legend-container",
+                                className="legend-container slide-init slide-in stagger-1",
                                 style={"--slide-distance": "4rem"},
                             ),
                             # Hotel booking link that appears when a casino is selected
@@ -196,13 +196,13 @@ def sticky_header(df):
             # Week Label and dynamic day headers
             html.Div(
                 id="week-label",
-                className="week-label slide-init slide-in stagger-1",
+                className="week-label slide-init slide-in stagger-2",
                 style={"--slide-distance": "8rem"},
                 children="",
             ),
             html.Div(
                 id="day-label-row",
-                className="day-label-wrapper slide-init slide-in stagger-2",
+                className="day-label-wrapper slide-init slide-in stagger-3",
                 style={"--slide-distance": "8rem"},
             ),
         ],

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -157,7 +157,7 @@ def sticky_header(df):
                             html.Div(
                                 create_legend(df),
                                 className="legend-container slide-init slide-in stagger-3",
-                                style={"opacity": 0},
+                                style={"--slide-distance": "4rem"},
                             ),
                             # Hotel booking link that appears when a casino is selected
                             html.Div(
@@ -190,20 +190,20 @@ def sticky_header(df):
                     "display": "flex",
                     "justifyContent": "space-between",
                     "paddingBottom": "10px",
-                    "--slide-distance": "6rem",
+                    "--slide-distance": "8rem",
                 },
             ),
             # Week Label and dynamic day headers
             html.Div(
                 id="week-label",
                 className="week-label slide-init slide-in stagger-1",
-                style={"--slide-distance": "6rem", "opacity": 0},
+                style={"--slide-distance": "8rem"},
                 children="",
             ),
             html.Div(
                 id="day-label-row",
                 className="day-label-wrapper slide-init slide-in stagger-2",
-                style={"--slide-distance": "6rem", "opacity": 0},
+                style={"--slide-distance": "8rem"},
             ),
         ],
         className="sticky-header",

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -139,7 +139,7 @@ def sticky_header(df):
             # Navigation & Legend
             html.Div(
                 id="header-container",
-                className="legend-container",
+                className="legend-container slide-in stagger-3",
                 children=[
                     html.Button(
                         "🎲",
@@ -186,11 +186,21 @@ def sticky_header(df):
                     "display": "flex",
                     "justifyContent": "space-between",
                     "paddingBottom": "10px",
+                    "--slide-distance": "1rem",
                 },
             ),
             # Week Label and dynamic day headers
-            html.Div(id="week-label", className="fade-text week-label", children=""),
-            html.Div(id="day-label-row", className="day-label-wrapper"),
+            html.Div(
+                id="week-label",
+                className="week-label slide-in stagger-1",
+                style={"--slide-distance": "1rem"},
+                children="",
+            ),
+            html.Div(
+                id="day-label-row",
+                className="day-label-wrapper slide-in stagger-2",
+                style={"--slide-distance": "1rem"},
+            ),
         ],
         className="sticky-header",
     )

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -157,6 +157,7 @@ def sticky_header(df):
                             html.Div(
                                 create_legend(df),
                                 className="legend-container slide-init slide-in stagger-3",
+                                style={"opacity": 0},
                             ),
                             # Hotel booking link that appears when a casino is selected
                             html.Div(
@@ -189,20 +190,20 @@ def sticky_header(df):
                     "display": "flex",
                     "justifyContent": "space-between",
                     "paddingBottom": "10px",
-                    "--slide-distance": "2rem",
+                    "--slide-distance": "6rem",
                 },
             ),
             # Week Label and dynamic day headers
             html.Div(
                 id="week-label",
                 className="week-label slide-init slide-in stagger-1",
-                style={"--slide-distance": "2rem"},
+                style={"--slide-distance": "6rem", "opacity": 0},
                 children="",
             ),
             html.Div(
                 id="day-label-row",
                 className="day-label-wrapper slide-init slide-in stagger-2",
-                style={"--slide-distance": "2rem"},
+                style={"--slide-distance": "6rem", "opacity": 0},
             ),
         ],
         className="sticky-header",

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -156,7 +156,7 @@ def sticky_header(df):
                             ),
                             html.Div(
                                 create_legend(df),
-                                className="legend-container slide-init slide-in stagger-1",
+                                className="legend-container",
                             ),
                             # Hotel booking link that appears when a casino is selected
                             html.Div(
@@ -195,12 +195,12 @@ def sticky_header(df):
             # Week Label and dynamic day headers
             html.Div(
                 id="week-label",
-                className="week-label slide-init slide-in stagger-2",
+                className="week-label",
                 children="",
             ),
             html.Div(
                 id="day-label-row",
-                className="day-label-wrapper slide-init slide-in stagger-3",
+                className="day-label-wrapper",
             ),
         ],
         className="sticky-header",

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -156,7 +156,7 @@ def sticky_header(df):
                             ),
                             html.Div(
                                 create_legend(df),
-                                className="legend-container slide-init slide-in stagger-3",
+                                className="legend-container",
                                 style={"--slide-distance": "4rem"},
                             ),
                             # Hotel booking link that appears when a casino is selected

--- a/app_components/utils.py
+++ b/app_components/utils.py
@@ -116,7 +116,7 @@ def build_event_info_rows(data: Iterable[tuple[str, Any]]) -> list[Any]:
     mapping = dict(data)
     emoji = offer_type_emoji(mapping.get("OfferType", ""))
     rows: list[Any] = [
-        html.H2(f"{emoji} Promo Info {emoji}", className="event-label-title")
+        html.H2(f"{emoji} Event Detail {emoji}", className="event-label-title")
     ]
 
     for label in [

--- a/assets/style.css
+++ b/assets/style.css
@@ -1094,8 +1094,8 @@ h1,
   }
 }
 .slide-init {
-  opacity: 0;
-  transform: translateY(var(--slide-distance));
+  opacity: 0 !important;
+  transform: translateY(-2rem) !important;
 }
 
 .slide-in {
@@ -1103,20 +1103,24 @@ h1,
 }
 
 .stagger-1 {
-  animation-delay: 0.5s;
+  animation-delay: 0.8s;
 }
 
 .stagger-2 {
-  animation-delay: 1s;
+  animation-delay: 1.6s;
 }
 
 .stagger-3 {
-  animation-delay: 1.5s;
+  animation-delay: 2.4s;
+}
+
+.stagger-4 {
+  animation-delay: 3.2s;
 }
 
 @keyframes slide-in {
   from {
-    transform: translateY(var(--slide-distance));
+    transform: translateY(-2rem);
     opacity: 0;
   }
   to {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1070,15 +1070,13 @@ h1,
   opacity: 0;
   overflow: visible;
   pointer-events: none;
-  transition: max-height 1.2s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-  transition-delay: 0s, 0.8s;
+  transition: max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .overflow-box-expand.show {
   max-height: var(--overflow-expand-max-height);
   opacity: 1;
   pointer-events: auto;
-  transition-delay: 0.4s, 0.8s;
 }
 
 .fade-text {
@@ -1095,8 +1093,25 @@ h1,
     transform: translateY(0);
   }
 }
+.slide-init {
+  opacity: 0;
+  transform: translateY(var(--slide-distance));
+}
+
 .slide-in {
   animation: slide-in 0.8s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+.stagger-1 {
+  animation-delay: 0.5s;
+}
+
+.stagger-2 {
+  animation-delay: 1s;
+}
+
+.stagger-3 {
+  animation-delay: 1.5s;
 }
 
 @keyframes slide-in {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1095,7 +1095,7 @@ h1,
 }
 .slide-init {
   opacity: 0 !important;
-  transform: translateY(-2rem) !important;
+  transform: translateY(-1rem) !important;
 }
 
 .slide-in {
@@ -1120,12 +1120,12 @@ h1,
 
 @keyframes slide-in {
   from {
-    transform: translateY(-2rem);
+    transform: translateY(-1rem);
     opacity: 0;
   }
   to {
     transform: translateY(0);
-    opacity: 1;
+    opacity: 1 !important;
   }
 }
 @keyframes slide-out {

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -36,7 +36,7 @@
 // Elements start hidden and translated so they can slide into view
 .slide-init {
     opacity: 0 !important;
-    transform: translateY(-2rem) !important;
+    transform: translateY(-1rem) !important;
 }
 
 .slide-in {
@@ -61,13 +61,13 @@
 
 @keyframes slide-in {
     from {
-        transform: translateY(-2rem);
+        transform: translateY(-1rem);
         opacity: 0;
     }
 
     to {
         transform: translateY(0);
-        opacity: 1;
+        opacity: 1 !important;
     }
 }
 

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -5,15 +5,13 @@
     opacity: 0;
     overflow: visible;
     pointer-events: none;
-    transition: max-height 1.2s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-    transition-delay: 0s, 0.8s;
+    transition: max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .overflow-box-expand.show {
     max-height: var(--overflow-expand-max-height);
     opacity: 1;
     pointer-events: auto;
-    transition-delay: 0.4s, 0.8s;
 }
 
 
@@ -36,6 +34,18 @@
 
 .slide-in {
     animation: slide-in 0.8s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+.stagger-1 {
+    animation-delay: 0.1s;
+}
+
+.stagger-2 {
+    animation-delay: 0.2s;
+}
+
+.stagger-3 {
+    animation-delay: 0.3s;
 }
 
 @keyframes slide-in {

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -36,7 +36,7 @@
 // Elements start hidden and translated so they can slide into view
 .slide-init {
     opacity: 0 !important;
-    transform: translateY(var(--slide-distance)) !important;
+    transform: translateY(-2rem) !important;
 }
 
 .slide-in {
@@ -61,7 +61,7 @@
 
 @keyframes slide-in {
     from {
-        transform: translateY(var(--slide-distance));
+        transform: translateY(-2rem);
         opacity: 0;
     }
 

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -35,24 +35,30 @@
 
 // Elements start hidden and translated so they can slide into view
 .slide-init {
-    opacity: 0;
-    transform: translateY(var(--slide-distance));
+    opacity: 0 !important;
+    transform: translateY(var(--slide-distance)) !important;
+    visibility: hidden;
 }
 
 .slide-in {
+    visibility: visible;
     animation: slide-in 0.8s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 .stagger-1 {
-    animation-delay: 0.5s;
+    animation-delay: 0.8s;
 }
 
 .stagger-2 {
-    animation-delay: 1s;
+    animation-delay: 1.6s;
 }
 
 .stagger-3 {
-    animation-delay: 1.5s;
+    animation-delay: 2.4s;
+}
+
+.stagger-4 {
+    animation-delay: 3.2s;
 }
 
 @keyframes slide-in {

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -35,8 +35,8 @@
 
 // Elements start hidden and translated so they can slide into view
 .slide-init {
-    opacity: 0 !important;
-    transform: translateY(-1rem) !important;
+    opacity: 0;
+    transform: translateY(-1rem);
 }
 
 .slide-in {

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -61,7 +61,7 @@
 
 @keyframes slide-in {
     from {
-        transform: translateY(-1rem);
+        transform: translateY(1rem);
         opacity: 0;
     }
 

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -32,20 +32,25 @@
     }
 }
 
+.slide-init {
+    opacity: 0;
+    transform: translateY(var(--slide-distance));
+}
+
 .slide-in {
     animation: slide-in 0.8s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 .stagger-1 {
-    animation-delay: 0.1s;
-}
-
-.stagger-2 {
     animation-delay: 0.2s;
 }
 
+.stagger-2 {
+    animation-delay: 0.4s;
+}
+
 .stagger-3 {
-    animation-delay: 0.3s;
+    animation-delay: 0.6s;
 }
 
 @keyframes slide-in {

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -33,11 +33,11 @@
 }
 
 
-// Elements start hidden and translated so they can slide into view
-.slide-init {
-    opacity: 0;
-    transform: translateY(-1rem);
-}
+// Animation classes temporarily disabled for testing
+// .slide-init {
+//     opacity: 0;
+//     transform: translateY(-1rem);
+// }
 
 .slide-in {
     animation: slide-in 0.8s cubic-bezier(0.4, 0, 0.2, 1) forwards;

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -37,11 +37,9 @@
 .slide-init {
     opacity: 0 !important;
     transform: translateY(var(--slide-distance)) !important;
-    visibility: hidden;
 }
 
 .slide-in {
-    visibility: visible;
     animation: slide-in 0.8s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -32,6 +32,8 @@
     }
 }
 
+
+// Elements start hidden and translated so they can slide into view
 .slide-init {
     opacity: 0;
     transform: translateY(var(--slide-distance));
@@ -42,15 +44,15 @@
 }
 
 .stagger-1 {
-    animation-delay: 0.2s;
+    animation-delay: 0.5s;
 }
 
 .stagger-2 {
-    animation-delay: 0.4s;
+    animation-delay: 1s;
 }
 
 .stagger-3 {
-    animation-delay: 0.6s;
+    animation-delay: 1.5s;
 }
 
 @keyframes slide-in {

--- a/assets/styles/_modal.scss
+++ b/assets/styles/_modal.scss
@@ -76,6 +76,7 @@
     font-size: var(--font-base);
     pointer-events: none;
     opacity: 0;
+    transform: translateY(-1rem);
     will-change: transform, opacity;
     transform-origin: center center;
     overflow-y: auto;
@@ -89,6 +90,7 @@
 .modal.show .modal-content {
     animation: slide-in 0.8s cubic-bezier(0.4, 0, 0.2, 1) forwards;
     pointer-events: auto;
+    opacity: 1 !important;
 }
 
 .modal.closing .modal-content {

--- a/assets/styles/_modal.scss
+++ b/assets/styles/_modal.scss
@@ -76,7 +76,7 @@
     font-size: var(--font-base);
     pointer-events: none;
     opacity: 0;
-    transform: translateY(-1rem);
+    transform: translateY(1rem);
     will-change: transform, opacity;
     transform-origin: center center;
     overflow-y: auto;


### PR DESCRIPTION
## Summary
- Speed up overflow box transition for quicker show/hide
- Animate legend, week label, and day labels with staggered slide-in effects
- Refresh header animations when navigating weeks

## Testing
- `npm run lint:css` *(fails: Unexpected empty line before rule etc.)*
- `npm run build:css`
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --check-only .` *(fails: imports incorrectly sorted)*
- `flake8 app_components tests` *(fails: E501 line too long and unused imports)*
- `pytest` *(fails: test_theme_variables::test_dark_theme_uses_primary_dark_instead_of_accent)*

------
https://chatgpt.com/codex/tasks/task_e_689827e66fcc832fbab588e8b44e2a3b