### PR TITLE
fix: resolve lint failures and dark theme color mapping

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import time
+
 from dash import Dash
 
 # Load environment variables from .env file early

--- a/app_components/callbacks/events.py
+++ b/app_components/callbacks/events.py
@@ -43,10 +43,13 @@ def register_callbacks(app, df) -> None:
 
             box_class = "overflow-box-expand show" if is_open else "overflow-box-expand"
 
+            date_range = (
+                f"{start_date.strftime('%b %d')} - {end_date.strftime('%b %d')}"
+            )
             button_text = (
-                f"\U0001f300 Hide Ongoing Events for {start_date.strftime('%b %d')} - {end_date.strftime('%b %d')}"
+                f"\U0001f300 Hide Ongoing Events for {date_range}"
                 if is_open
-                else f"\U0001f300 Show Ongoing Events for {start_date.strftime('%b %d')} - {end_date.strftime('%b %d')}"
+                else f"\U0001f300 Show Ongoing Events for {date_range}"
             )
 
             logger.debug(f"Overflow toggled: is_open={is_open}, class={box_class}")
@@ -210,7 +213,8 @@ def register_callbacks(app, df) -> None:
                     df[df["Casino"].isin(selected_casinos)] if selected_casinos else df
                 )
                 logger.debug(
-                    f"Filtered events to {len(filtered)} items based on selected casinos"
+                    "Filtered events to %d items based on selected casinos",
+                    len(filtered),
                 )
 
                 content = generate_day_view_html(
@@ -258,7 +262,8 @@ def register_callbacks(app, df) -> None:
                     clicked_date = week_start + timedelta(days=day_index)
 
                     logger.info(
-                        f"Opening day modal for day index {day_index}: {clicked_date.strftime('%Y-%m-%d')}"
+                        f"Opening day modal for day index {day_index}: "
+                        f"{clicked_date.strftime('%Y-%m-%d')}"
                     )
 
                     filtered = (
@@ -292,7 +297,8 @@ def register_callbacks(app, df) -> None:
                     ]
                 ):
                     logger.info(
-                        f"Opening event modal for: {data.get('EventName', 'Unknown Event')}"
+                        f"Opening event modal for: "
+                        f"{data.get('EventName', 'Unknown Event')}"
                     )
                     rows = build_event_info_rows(data.items())
                     return ({}, "modal show", rows, 0, {"display": "none"}, "", "")
@@ -300,7 +306,8 @@ def register_callbacks(app, df) -> None:
             logger.debug("No valid trigger found, preventing update")
             end_time = time.time()
             logger.debug(
-                f"show_event_modal callback completed in {end_time - start_time:.3f}s (PreventUpdate)"
+                f"show_event_modal callback completed in "
+                f"{end_time - start_time:.3f}s (PreventUpdate)"
             )
             raise dash.exceptions.PreventUpdate
 
@@ -308,7 +315,8 @@ def register_callbacks(app, df) -> None:
             # PreventUpdate is expected behavior, not an error - just re-raise it
             end_time = time.time()
             logger.debug(
-                f"show_event_modal callback completed in {end_time - start_time:.3f}s (PreventUpdate)"
+                f"show_event_modal callback completed in "
+                f"{end_time - start_time:.3f}s (PreventUpdate)"
             )
             raise
         except Exception as e:
@@ -316,7 +324,8 @@ def register_callbacks(app, df) -> None:
             # Log performance even on error
             end_time = time.time()
             logger.debug(
-                f"show_event_modal callback completed in {end_time - start_time:.3f}s (with error)"
+                f"show_event_modal callback completed in "
+                f"{end_time - start_time:.3f}s (with error)"
             )
             raise
 

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -1,10 +1,10 @@
 import json
-import time
 from datetime import datetime, timedelta
 from typing import Any, Tuple, cast
 from uuid import uuid4
 
 import dash
+import pandas as pd
 from dash import ALL, Input, Output, State, html
 from pytz import timezone
 
@@ -223,10 +223,13 @@ def register_callbacks(app, df) -> None:
             week_start_pdt = to_pdt(week_start)
             week_end_pdt = to_pdt(week_end)
             is_open = bool(selected_casinos)
+            week_range = (
+                f"{week_start_pdt.strftime('%b %d')} - {week_end_pdt.strftime('%b %d')}"
+            )
             toggle_text = (
-                f"\U0001f300 Hide Ongoing Events for {week_start_pdt.strftime('%b %d')} - {week_end_pdt.strftime('%b %d')}"
+                f"\U0001f300 Hide Ongoing Events for {week_range}"
                 if is_open
-                else f"\U0001f300 Show Ongoing Events for {week_start_pdt.strftime('%b %d')} - {week_end_pdt.strftime('%b %d')}"
+                else f"\U0001f300 Show Ongoing Events for {week_range}"
             )
             overflow_toggle = html.Button(
                 toggle_text,
@@ -234,6 +237,13 @@ def register_callbacks(app, df) -> None:
                 n_clicks=1 if is_open else 0,
                 className="overflow-toggle",
             )
+
+            def _format_overflow_item(row: pd.Series) -> html.Li:
+                start = to_pdt(cast(datetime, row["StartDate"])).strftime("%b %d")
+                end = to_pdt(cast(datetime, row["EndDate"])).strftime("%b %d")
+                text = f"{row['EventName']} ({row['Casino']}) - {start} to {end}"
+                return html.Li(text, style={"color": "#00008B"})
+
             overflow_box = html.Div(
                 id="overflow-box",
                 className="overflow-box-expand" + (" show" if is_open else ""),
@@ -245,12 +255,7 @@ def register_callbacks(app, df) -> None:
                     ),
                     html.Ul(
                         [
-                            html.Li(
-                                f"{row['EventName']} ({row['Casino']}) - "
-                                f"{to_pdt(cast(datetime, row['StartDate'])).strftime('%b %d')} to "
-                                f"{to_pdt(cast(datetime, row['EndDate'])).strftime('%b %d')}",
-                                style={"color": "#00008B"},
-                            )
+                            _format_overflow_item(row)
                             for _, row in overflow_df.iterrows()
                         ]
                     ),

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -1,7 +1,7 @@
 import plotly.graph_objs as go
 from dash import dcc, html
-
 from utils.colors import get_color
+
 from .logging_config import setup_logger
 
 # Initialize module logger
@@ -35,7 +35,9 @@ def create_layout(app, df):
                                     color="#6A5ACD",
                                     children=html.Div(
                                         id="week-chart-container",
-                                        className="week-gap section-margin calendar-content",
+                                        className=(
+                                            "week-gap section-margin calendar-content"
+                                        ),
                                     ),
                                 ),
                             ],

--- a/app_components/logging_config.py
+++ b/app_components/logging_config.py
@@ -26,7 +26,7 @@ except ImportError:
 
 # Import our custom log rotation utilities
 try:
-    from utils.log_rotation import setup_rotating_logger, cleanup_old_logs
+    from utils.log_rotation import cleanup_old_logs, setup_rotating_logger
 except ImportError:
     # Fallback if utils module not available
     setup_rotating_logger = None
@@ -129,7 +129,8 @@ def _suppress_http_logs():
     if suppressed_count > 0:
         # Use print instead of logging to avoid circular dependencies
         print(
-            f"🔇 HTTP request logs suppressed for console output ({suppressed_count} handlers removed)"
+            "🔇 HTTP request logs suppressed for console output "
+            f"({suppressed_count} handlers removed)"
         )
     else:
         print("🔇 HTTP request logs suppressed (set to WARNING level)")

--- a/app_components/plotting.py
+++ b/app_components/plotting.py
@@ -33,7 +33,8 @@ def get_layout_config(screen_width: int) -> Tuple[int, int]:
     return hour_height, label_column_pct
 
 
-# Generate a responsive 24-hour vertical day view with absolutely positioned event blocks.
+# Generate a responsive 24-hour vertical day view with absolutely
+# positioned event blocks.
 def generate_day_view_html(
     events_df: pd.DataFrame,
     clicked_date: datetime,
@@ -503,7 +504,10 @@ def build_weekly_figure(events_df, screen_width, week_start):
             start_day = max(0, floor(visible_start))
             end_day = min(6, floor(visible_end - 1e-6))
 
-            recurring_key = f"{row['EventName']}|{row['Casino']}|{row['StartDate'].time()}|{row['EndDate'].time()}"
+            recurring_key = (
+                f"{row['EventName']}|{row['Casino']}|"
+                f"{row['StartDate'].time()}|{row['EndDate'].time()}"
+            )
             preferred_row = recurring_rows.get(recurring_key)
             row_assigned = False
 
@@ -563,7 +567,10 @@ def build_weekly_figure(events_df, screen_width, week_start):
                 shapes.append(
                     dict(
                         type="path",
-                        path=f"M 0,{y_center} L{ARROW_OFFSET},{y_center + 0.2} L{ARROW_OFFSET},{y_center - 0.2} Z",
+                        path=(
+                            f"M 0,{y_center} L{ARROW_OFFSET},{y_center + 0.2} "
+                            f"L{ARROW_OFFSET},{y_center - 0.2} Z"
+                        ),
                         fillcolor="black",
                         line=dict(color="black", width=1),
                         layer="above",
@@ -574,7 +581,10 @@ def build_weekly_figure(events_df, screen_width, week_start):
                 shapes.append(
                     dict(
                         type="path",
-                        path=f"M 7,{y_center} L{7 - ARROW_OFFSET},{y_center + 0.2} L{7 - ARROW_OFFSET},{y_center - 0.2} Z",
+                        path=(
+                            f"M 7,{y_center} L{7 - ARROW_OFFSET},{y_center + 0.2} "
+                            f"L{7 - ARROW_OFFSET},{y_center - 0.2} Z"
+                        ),
                         fillcolor="black",
                         line=dict(color="black", width=1),
                         layer="above",
@@ -643,7 +653,10 @@ def build_weekly_figure(events_df, screen_width, week_start):
                 tickmode="array",
                 tickvals=[i + 0.5 for i in range(7)],
                 ticktext=[
-                    f"<b style='color:#00008B;font-size:{event_font_size_px}px'>{label}</b>"
+                    (
+                        "<b style='color:#00008B;font-size:"
+                        f"{event_font_size_px}px'>{label}</b>"
+                    )
                     for label in tick_labels
                 ],
                 side="top",

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -236,11 +236,10 @@ h1,
 }
 
 [data-theme="dark"] {
-
     .hour-label,
     .day-label,
     .overflow-box {
-        color: var(--color-accent);
+        color: var(--color-primary-dark);
     }
 
     .event-label-title,

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -9,7 +9,6 @@ body {
 }
 
 @include mixins.mobile {
-
     html,
     body {
         height: auto;
@@ -113,7 +112,7 @@ body {
     }
 
     // Disable sticky header for landscape phones //
-    @media (max-width: 896px) and (orientation: landscape) {
+    @media (width <= 896px) and (orientation: landscape) {
         position: static;
     }
 }

--- a/assets/styles/_mixins.scss
+++ b/assets/styles/_mixins.scss
@@ -1,26 +1,25 @@
 /* Responsive breakpoints mixins */
 @mixin mobile {
-
-    @media (max-width: 480px),
-    (max-width: 896px) and (orientation: landscape) {
+    @media (width <= 480px),
+    (width <= 896px) and (orientation: landscape) {
         @content;
     }
 }
 
 @mixin tablet {
-    @media (max-width: 768px) {
+    @media (width <= 768px) {
         @content;
     }
 }
 
 @mixin desktop {
-    @media (min-width: 1024px) {
+    @media (width >= 1024px) {
         @content;
     }
 }
 
 @mixin hd {
-    @media (min-width: 1440px) {
+    @media (width >= 1440px) {
         @content;
     }
 }

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -36,9 +36,9 @@
     --color-accent: #6A5ACD;
     --color-accent-dark: #483D8B;
     --color-background: #f5f3fa;
-    --color-white: #ffffff;
-    --color-black: #000000;
-    --color-accent-light: rgba(106, 90, 205, 0.1);
+    --color-white: #fff;
+    --color-black: #000;
+    --color-accent-light: rgb(106 90 205 / 10%);
 
     /* Day Header & Week Grid Colors */
     --color-day-header-text: var(--color-accent);
@@ -46,7 +46,7 @@
     --color-border-primary: var(--color-primary-dark);
     --color-border-accent: var(--color-accent);
     --color-border-grid: #7F8BAA;
-    --color-border-grid-light: rgba(127, 139, 170, 0.3);
+    --color-border-grid-light: rgb(127 139 170 / 30%);
 
     /* Borders and shadows */
     --border-radius-lg: 0.625rem;
@@ -74,7 +74,7 @@
     --day-modal-min-width: 18rem;
     --day-modal-max-width-desktop: 70rem;
     --day-modal-max-width-hd: 90rem;
-    --modal-overlay-color: rgba(0, 0, 0, 0.25);
+    --modal-overlay-color: rgb(0 0 0 / 25%);
     --modal-overlay-blur: 0.25rem;
 
     /* Animation distances */
@@ -92,7 +92,7 @@
 }
 
 /* Font and spacing adjustments for small screens */
-@media (max-width: 480px) {
+@media (width <= 480px) {
     :root {
         --font-xxs: 0.35rem;
         --font-xs: 0.45rem;
@@ -105,7 +105,7 @@
 }
 
 /* Slightly larger fonts for landscape phones */
-@media (max-width: 896px) and (orientation: landscape) {
+@media (width <= 896px) and (orientation: landscape) {
     :root {
         --font-xxs: 0.45rem;
         --font-xs: 0.55rem;
@@ -161,31 +161,26 @@ body {
     /* Text colors - professional with more color */
     --color-primary-dark: #6a5acd;
     /* SlateBlue for primary elements */
-    --color-accent: #a78bfa;
-    /* Light purple for accent elements */
-    --color-primary-light: rgba(106, 90, 205, 0.15);
-    /* Subtle accent background */
-    --color-black: #a78bfa;
-    /* Override black to match accent */
+    --color-primary-light: rgb(106 90 205 / 15%);
+    /* Subtle primary background */
+    --color-black: var(--color-primary-dark);
+    /* Use primary tone for high-contrast text */
     --color-white: #2d2d30;
     /* Use background color for "white" elements */
 
     /* Header and border colors */
-    --color-day-header-text: #a78bfa;
+    --color-day-header-text: var(--color-primary-dark);
     --color-day-header-bg: #2d2d30;
     --color-border-primary: #7dd3fc;
     --color-border-grid: #7dd3fc;
-    --color-border-grid-light: rgb(125 211 252 / 0.3);
+    --color-border-grid-light: rgb(125 211 252 / 30%);
 
     /* Shadows - light blue-ish */
-    --box-shadow-light: 0 -0.125rem 0.3125rem rgb(125 211 252 / 0.4);
-    --box-shadow-modal: 0 0 1.25rem rgb(125 211 252 / 0.2);
-    --box-shadow-subtle: 0 -0.0625rem 0.3125rem rgba(125, 211, 252, 0.3);
-}
+    --box-shadow-light: 0 -0.125rem 0.3125rem rgb(125 211 252 / 40%);
+    --box-shadow-modal: 0 0 1.25rem rgb(125 211 252 / 20%);
+    --box-shadow-subtle: 0 -0.0625rem 0.3125rem rgb(125 211 252 / 30%);
 
-/* Global override to soften casino colors in dark mode */
-[data-theme="dark"] {
-
+    /* Global override to soften casino colors in dark mode */
     .event-block-grid,
     .event-block-day {
         z-index: 25 !important;

--- a/config/.flake8
+++ b/config/.flake8
@@ -1,5 +1,6 @@
 [flake8]
-max-line-length = 150
+max-line-length = 88
+extend-ignore = E203, W503
 exclude =
     .venv,
     node_modules

--- a/scripts/dev/test_day_modal_fix.py
+++ b/scripts/dev/test_day_modal_fix.py
@@ -2,8 +2,9 @@
 """
 Quick test script to verify the day modal improvements.
 """
-import pandas as pd
 from datetime import datetime
+
+import pandas as pd
 from app_components.plotting import generate_day_view_html
 from utils.colors import get_color
 

--- a/scripts/dev/test_imports.py
+++ b/scripts/dev/test_imports.py
@@ -2,8 +2,8 @@
 """
 Simple test script to verify the Casino Calendar application can be imported and run.
 """
-import sys
 import os
+import sys
 from pathlib import Path
 
 # Add the project root to the Python path

--- a/scripts/maintenance/cleanup_logs.py
+++ b/scripts/maintenance/cleanup_logs.py
@@ -13,9 +13,9 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from utils.log_rotation import (
+    archive_current_log,
     cleanup_old_logs,
     get_log_directory_info,
-    archive_current_log,
 )
 
 

--- a/tests/test_breakpoints.py
+++ b/tests/test_breakpoints.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 import pytest
-
 from app_components.utils import to_naive_utc
 from app_components.week_grid_layout import _build_block
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -2,11 +2,10 @@ from datetime import datetime
 
 import pandas as pd
 import pytest
-from dash import Dash
-from freezegun import freeze_time
-
 from app_components.callbacks import register_callbacks
 from app_components.utils import to_naive_utc
+from dash import Dash
+from freezegun import freeze_time
 
 
 class DummyCtx:
@@ -40,7 +39,10 @@ def test_update_week_offset_next(monkeypatch, casino):
     app = Dash(__name__)
     register_callbacks(app, df)
     func = app.callback_map[
-        "..week-offset.data...prev-button.disabled...next-button.disabled...next-button.title.."
+        (
+            "..week-offset.data...prev-button.disabled...next-button.disabled..."
+            "next-button.title.."
+        )
     ]["callback"].__wrapped__
 
     monkeypatch.setattr("dash.callback_context", DummyCtx("next-button"), raising=False)
@@ -68,7 +70,10 @@ def test_update_week_offset_no_next(monkeypatch, casino):
     app = Dash(__name__)
     register_callbacks(app, df)
     func = app.callback_map[
-        "..week-offset.data...prev-button.disabled...next-button.disabled...next-button.title.."
+        (
+            "..week-offset.data...prev-button.disabled...next-button.disabled..."
+            "next-button.title.."
+        )
     ]["callback"].__wrapped__
 
     monkeypatch.setattr("dash.callback_context", DummyCtx("next-button"), raising=False)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-
 from app_components.data import categorize_offer_type_updated, load_event_data
 
 

--- a/tests/test_day_modal_boundary_cases.py
+++ b/tests/test_day_modal_boundary_cases.py
@@ -2,12 +2,12 @@
 """
 Test script to verify day modal logic includes all boundary cases.
 """
-import pandas as pd
 from datetime import datetime, timedelta
 
+import pandas as pd
 from app_components.plotting import generate_day_view_html
-from utils.colors import get_color
 from app_components.utils import to_naive_utc
+from utils.colors import get_color
 
 
 def test_day_modal_boundary_cases():
@@ -94,7 +94,6 @@ def test_day_modal_boundary_cases():
     # Check that we generated the expected elements
     assert len(result) >= 2, "Should generate header and grid elements"
 
-    header = result[0]
     grid = result[1]
 
     # Check that we have the grid with event blocks
@@ -162,10 +161,12 @@ def test_day_modal_midnight_boundary_edge_case():
         and "event-block-day" in child.className
     ]
 
-    # Event ending exactly at midnight SHOULD be included (boundary is inclusive with >= operator)
-    assert (
-        len(event_blocks) == 1
-    ), f"Event ending exactly at midnight should be included with >= boundary, got {len(event_blocks)} events"
+    # Event ending exactly at midnight SHOULD be included
+    # boundary is inclusive with >= operator
+    assert len(event_blocks) == 1, (
+        "Event ending exactly at midnight should be included with >= boundary, "
+        f"got {len(event_blocks)} events"
+    )
 
 
 def test_day_modal_midnight_boundary_inclusive_case():
@@ -203,6 +204,7 @@ def test_day_modal_midnight_boundary_inclusive_case():
     ]
 
     # Event ending 1 minute into the day should be included
-    assert (
-        len(event_blocks) == 1
-    ), f"Event ending just after midnight should be included, got {len(event_blocks)} events"
+    assert len(event_blocks) == 1, (
+        "Event ending just after midnight should be included, "
+        f"got {len(event_blocks)} events"
+    )

--- a/tests/test_day_modal_sorting.py
+++ b/tests/test_day_modal_sorting.py
@@ -3,8 +3,9 @@
 Test the sorting logic for event blocks in the day modal.
 """
 
-import pandas as pd
 from datetime import datetime
+
+import pandas as pd
 from app_components.plotting import generate_day_view_html
 from utils.colors import get_color
 
@@ -44,7 +45,8 @@ def test_day_modal_sorting():
             {
                 "EventName": "Same Casino Different Category 1",
                 "Casino": "Casino A",
-                "OfferType": "Free-Play",  # Should come before Point-Based alphabetically
+                "OfferType": "Free-Play",
+                # Should come before Point-Based alphabetically
                 "Offer": "Same casino category 1",
                 "StartDate": pd.Timestamp("2025-08-06 14:00:00"),  # 2 PM
                 "EndDate": pd.Timestamp("2025-08-06 16:00:00"),

--- a/tests/test_logging_system.py
+++ b/tests/test_logging_system.py
@@ -2,13 +2,13 @@
 
 import os
 import tempfile
-import pytest
 from unittest.mock import patch
 
+import pytest
 from app_components.logging_config import (
-    setup_logger,
-    get_log_level,
     CasinoCalendarFormatter,
+    get_log_level,
+    setup_logger,
 )
 
 
@@ -108,9 +108,9 @@ def test_app_import_with_logging():
     """Test that the main app can be imported with logging enabled."""
     # This is a basic smoke test to ensure our logging changes don't break imports
     try:
-        import app_components.logging_config
         import app_components.data
-        import utils.colors
+        import app_components.logging_config  # noqa: F401 - verify import side effects
+        import utils.colors  # noqa: F401 - verify import side effects
 
         # If we get here without exceptions, the test passes
         assert True

--- a/tests/test_modals.py
+++ b/tests/test_modals.py
@@ -2,10 +2,9 @@ from datetime import datetime
 
 import pandas as pd
 import pytest
-from dash import Dash
-
 from app_components.callbacks import register_callbacks
 from app_components.utils import to_naive_utc
+from dash import Dash
 from utils import data_parsing
 
 
@@ -28,9 +27,12 @@ def _create_app(casino: str):
     )
     app = Dash(__name__)
     register_callbacks(app, df)
-    key = (
-        "..event-modal.style...event-modal.className...event-modal-body.children"
-        "...close-timer.n_intervals...day-modal.style...day-modal.className...day-modal-body.children.."
+    key = "".join(
+        [
+            "..event-modal.style...event-modal.className...event-modal-body.children",
+            "...close-timer.n_intervals...day-modal.style...day-modal.className...",
+            "day-modal-body.children..",
+        ]
     )
     func = app.callback_map[key]["callback"].__wrapped__
     return func

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 import pytest
-
 from app_components.utils import filter_long_spanning_events, to_naive_utc
 
 

--- a/tests/test_text_overflow.py
+++ b/tests/test_text_overflow.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 import pytest
-
 from app_components.utils import offer_type_emoji, to_naive_utc
 from app_components.week_grid_layout import _build_block
 

--- a/tests/test_theme_visual.py
+++ b/tests/test_theme_visual.py
@@ -74,8 +74,14 @@ def test_accent_elements_switch_to_primary_dark(dash_duo, tmp_path):
 
     def css_var_to_rgb(name):
         return dash_duo.driver.execute_script(
-            "var s=getComputedStyle(document.documentElement).getPropertyValue(arguments[0]).trim();"
-            "var d=document.createElement('div');d.style.color=s;document.body.appendChild(d);"
+            (
+                "var s=getComputedStyle(document.documentElement)"
+                ".getPropertyValue(arguments[0]).trim();"
+            ),
+            (
+                "var d=document.createElement('div');"
+                "d.style.color=s;document.body.appendChild(d);"
+            ),
             "var c=getComputedStyle(d).color;d.remove();return c;",
             name,
         )

--- a/tests/test_week_events.py
+++ b/tests/test_week_events.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 import pytest
-
 from app_components.utils import to_naive_utc
 from utils.data_parsing import prepare_week_events
 

--- a/tests/test_week_label.py
+++ b/tests/test_week_label.py
@@ -1,8 +1,7 @@
 import pandas as pd
+from app_components.callbacks import register_callbacks
 from dash import Dash
 from freezegun import freeze_time
-
-from app_components.callbacks import register_callbacks
 
 
 @freeze_time("2025-04-15")

--- a/utils/data_parsing.py
+++ b/utils/data_parsing.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from math import floor
 
 import pandas as pd
-
 from app_components.logging_config import setup_logger
 
 # Initialize module logger


### PR DESCRIPTION
## Summary
- sort imports and resolve Python lint warnings
- clean up SCSS stylelint issues
- map dark theme to use primary color variables

## Testing
- `npm run lint:css`
- `npm run build:css`
- `python -m py_compile app.py app_components/*.py`
- `black --check .`
- `isort --settings-path config/.isort.cfg --check-only .`
- `flake8 --config config/.flake8 app_components tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68982aef8094832fbec3c7da9772eaac