### PR TITLE
feat: cache configuration files at startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from app_components.callbacks import register_callbacks
 from app_components.data import load_event_data
 from app_components.layout import create_layout
 from app_components.logging_config import setup_logger
+from utils.config_cache import get_config
 
 # Initialize application logger
 logger = setup_logger(__name__)
@@ -23,6 +24,10 @@ app.title = "Casino Event Calendar"
 
 logger.info("Casino Calendar application starting up")
 logger.debug(f"Dash app initialized with title: {app.title}")
+
+# Preload configuration files so they are cached at startup
+get_config("casino_colors.json")
+get_config("default_colors.json")
 
 app.index_string = """
 <!DOCTYPE html>

--- a/tests/test_config_cache.py
+++ b/tests/test_config_cache.py
@@ -1,0 +1,37 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+
+UTILS_DIR = Path(__file__).resolve().parents[1] / "utils"
+sys.path.insert(0, str(UTILS_DIR))
+config_cache = importlib.import_module("config_cache")
+
+
+def test_get_config_caches(tmp_path, monkeypatch):
+    config_cache._CACHE.clear()
+    monkeypatch.setattr(config_cache, "DATA_DIR", tmp_path)
+    config_file = tmp_path / "sample.json"
+    config_file.write_text(json.dumps({"a": 1}), encoding="utf-8")
+
+    first = config_cache.get_config("sample.json")
+    config_file.write_text(json.dumps({"a": 2}), encoding="utf-8")
+    second = config_cache.get_config("sample.json")
+
+    assert first == {"a": 1}
+    assert second == {"a": 1}
+
+
+def test_get_config_cache_bust(tmp_path, monkeypatch):
+    config_cache._CACHE.clear()
+    monkeypatch.setattr(config_cache, "DATA_DIR", tmp_path)
+    config_file = tmp_path / "sample.json"
+    config_file.write_text(json.dumps({"a": 1}), encoding="utf-8")
+
+    first = config_cache.get_config("sample.json")
+    config_file.write_text(json.dumps({"a": 2}), encoding="utf-8")
+    monkeypatch.setenv("CONFIG_CACHE_BUST", "1")
+    second = config_cache.get_config("sample.json")
+
+    assert first == {"a": 1}
+    assert second == {"a": 2}

--- a/utils/colors.py
+++ b/utils/colors.py
@@ -1,34 +1,20 @@
-import json
-from pathlib import Path
-
 from app_components.logging_config import setup_logger
+from utils.config_cache import get_config
 
 # Initialize module logger
 logger = setup_logger(__name__)
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+COLOR_MAP = get_config("casino_colors.json") or {}
+if COLOR_MAP:
+    logger.debug("Loaded casino colors for %d casinos", len(COLOR_MAP))
+else:
+    logger.warning("Casino colors unavailable, falling back to defaults")
 
-try:
-    with open(DATA_DIR / "casino_colors.json", encoding="utf-8") as f:
-        COLOR_MAP = json.load(f)
-    logger.debug(f"Loaded casino colors for {len(COLOR_MAP)} casinos")
-except FileNotFoundError:
-    logger.error(f"Casino colors file not found: {DATA_DIR / 'casino_colors.json'}")
-    COLOR_MAP = {}
-except json.JSONDecodeError as e:
-    logger.error(f"Invalid JSON in casino colors file: {e}", exc_info=True)
-    COLOR_MAP = {}
-
-try:
-    with open(DATA_DIR / "default_colors.json", encoding="utf-8") as f:
-        DEFAULT_COLORS = json.load(f)
-    logger.debug(f"Loaded {len(DEFAULT_COLORS)} default colors")
-except FileNotFoundError:
-    logger.error(f"Default colors file not found: {DATA_DIR / 'default_colors.json'}")
-    DEFAULT_COLORS = []
-except json.JSONDecodeError as e:
-    logger.error(f"Invalid JSON in default colors file: {e}", exc_info=True)
-    DEFAULT_COLORS = []
+DEFAULT_COLORS = get_config("default_colors.json") or []
+if DEFAULT_COLORS:
+    logger.debug("Loaded %d default colors", len(DEFAULT_COLORS))
+else:
+    logger.warning("Default colors unavailable")
 
 
 def get_color():

--- a/utils/config_cache.py
+++ b/utils/config_cache.py
@@ -1,0 +1,55 @@
+"""Centralized configuration caching utilities.
+
+Provides a simple JSON configuration cache to avoid repeated
+file reads for static configuration data.  The cache can be
+cleared by setting the environment variable ``CONFIG_CACHE_BUST``
+to any non-empty value.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from app_components.logging_config import setup_logger
+
+# Initialize module logger
+logger = setup_logger(__name__)
+
+# Module level cache storage
+_CACHE: Dict[str, Any] = {}
+
+# Directory containing configuration files
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+
+def get_config(filename: str) -> Any:
+    """Return the parsed contents of a JSON configuration file.
+
+    The file is read from :mod:`data` on first access and the result is
+    cached for subsequent calls.  Set the ``CONFIG_CACHE_BUST``
+    environment variable to force a reload during development.
+    """
+
+    if os.getenv("CONFIG_CACHE_BUST"):
+        logger.debug("CONFIG_CACHE_BUST set - clearing cache")
+        _CACHE.pop(filename, None)
+
+    if filename in _CACHE:
+        return _CACHE[filename]
+
+    path = DATA_DIR / filename
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        _CACHE[filename] = data
+        logger.debug("Loaded configuration %s", filename)
+        return data
+    except FileNotFoundError:
+        logger.error("Configuration file not found: %s", path)
+    except json.JSONDecodeError as e:
+        logger.error("Invalid JSON in %s: %s", path, e, exc_info=True)
+
+    # Cache empty fallback to avoid repeated file I/O on failure
+    _CACHE[filename] = None
+    return None


### PR DESCRIPTION
## Summary
- add JSON configuration cache utility with environment-based busting
- use cached configs for color mappings and preload at startup
- test configuration caching and cache bust behavior

## Testing
- `flake8 utils/config_cache.py utils/colors.py app.py tests/test_config_cache.py` *(fails: command not found)*
- `python -m py_compile app.py app_components/*.py`
- `pytest tests/test_config_cache.py -q`
- `scripts/test.sh` *(fails: 6 files would be reformatted)*

Closes Issue #172

------
https://chatgpt.com/codex/tasks/task_e_689a8a918aa8832fbac3894881810e3d