### PR TITLE
refactor: update day modal and event border colors

### DIFF
--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -247,8 +247,7 @@ h1,
     .event-label-title,
     .day-modal-title,
     .event-label strong,
-    .no-events,
-    .hour-label {
+    .no-events {
         color: var(--color-primary);
     }
 
@@ -256,7 +255,16 @@ h1,
     .legend-title,
     .overflow-box,
     .day-label-grid,
-    .overflow-toggle {
+    .overflow-toggle,
+    .hour-label {
+        color: var(--color-accent);
+    }
+
+    .day-label.day-modal-title {
+        color: var(--color-primary);
+    }
+
+    .overflow-box .event-label span {
         color: var(--color-accent);
     }
 

--- a/assets/styles/_modal.scss
+++ b/assets/styles/_modal.scss
@@ -145,7 +145,7 @@
 /* Event blocks displayed in the day view modal */
 .event-block-day {
     position: absolute;
-    border: var(--border-event) solid var(--color-border-accent);
+    border: var(--border-event) solid var(--color-accent);
     border-radius: var(--border-radius-sm);
     box-sizing: border-box;
     z-index: 10;
@@ -161,10 +161,6 @@
     background-color: var(--bg);
     color: var(--fg);
     box-shadow: var(--box-shadow-light);
-
-    [data-theme="dark"] & {
-        border: var(--border-event) solid var(--color-primary);
-    }
 }
 
 

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -54,7 +54,7 @@
     --border-radius-xs: 0.125rem;
     --border-thin: 1px;
     --border-thick: 0.125rem;
-    --border-event: 0.1875rem;
+    --border-event: 0.125rem;
     --box-shadow-light: 0 -0.125rem 0.3125rem var(--color-primary);
     --box-shadow-subtle: 0 -0.0625rem 0.3125rem var(--color-accent);
     --box-shadow-modal: 0 0 1.25rem var(--color-primary);


### PR DESCRIPTION
## Summary
- use primary color for combined day-label day-modal-title in dark theme and accent for hour labels
- style day event blocks with accent-colored borders
- reduce event border thickness variable for slimmer appearance

## Testing
- `npm run lint:css`
- `npm run build:css`
- `scripts/test.sh` *(fails: imports are incorrectly sorted and/or formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68a0252d5a18832fbf22e8a75d0cf2d6