### PR TITLE
feat: add home button to calendar title

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile = black

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ from utils.config_cache import warm_cache
 logger = setup_logger(__name__)
 
 app = Dash(__name__, suppress_callback_exceptions=True)
-app.title = "Casino Event Calendar"
+app.title = "Casino Events Calendar"
 
 logger.info("Casino Calendar application starting up")
 logger.debug(f"Dash app initialized with title: {app.title}")

--- a/app_components/callbacks/__init__.py
+++ b/app_components/callbacks/__init__.py
@@ -2,6 +2,7 @@
 
 from .events import register_callbacks as _register_event_callbacks
 from .filters import register_callbacks as _register_filter_callbacks
+from .navigation import register_callbacks as _register_navigation_callbacks
 from .theme import register_callbacks as _register_theme_callbacks
 
 
@@ -10,3 +11,4 @@ def register_callbacks(app, df):
     _register_event_callbacks(app, df)
     _register_filter_callbacks(app, df)
     _register_theme_callbacks(app, df)
+    _register_navigation_callbacks(app, df)

--- a/app_components/callbacks/navigation.py
+++ b/app_components/callbacks/navigation.py
@@ -1,0 +1,22 @@
+from dash import Input, Output
+
+from ..logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+
+def register_callbacks(app, _df) -> None:
+    """Register navigation callbacks."""
+    logger.info("Registering navigation callbacks")
+
+    @app.callback(
+        Output("home-url", "pathname"),
+        Input("home-button", "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def _navigate_home(_n_clicks: int) -> str:  # pragma: no cover - simple redirect
+        """Return root path when home button is clicked."""
+        logger.debug(f"Home button clicked: {_n_clicks}")
+        return "/"
+
+    logger.info("Navigation callbacks registered successfully")

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -19,6 +19,7 @@ def create_layout(app, df):
         layout = html.Div(
             className="main-layout",
             children=[
+                dcc.Location(id="home-url", refresh=True),
                 # Header section only (wrapped for height calc)
                 html.Div(
                     id="app-header",
@@ -128,7 +129,12 @@ def sticky_header(df):
         [
             html.H1(
                 [
-                    "🎰 Casino Event Calendar 📅",
+                    html.Button(
+                        "🎰 Casino Events Calendar 📅",
+                        id="home-button",
+                        n_clicks=0,
+                        className="calendar-title-home-button",
+                    ),
                     html.Button(
                         "🌙",
                         id="theme-toggle",

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -28,6 +28,19 @@ h1,
     transform: translateY(-50%);
 }
 
+.calendar-title-home-button {
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    padding: 0;
+}
+
+.calendar-title-home-button:focus {
+    outline: none;
+}
+
 .legend-title {
     font-size: clamp(var(--font-subtitle), 2.5vw, var(--font-header));
     font-weight: var(--font-weight-bold);


### PR DESCRIPTION
## Summary
- make Casino Events Calendar title a home button
- add navigation callback to reset URL
- style title button via SCSS and keep generated CSS uncommitted
- revert direct style.css changes to respect build process
- add root-level isort config and fix layout import grouping to clear sorting errors

## Testing
- `isort --check-only .`
- `npm run lint:css`
- `npm run build:css`
- `scripts/test.sh` *(fails: missing type stubs for pandas, dash, selenium, etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: dash)*

------
https://chatgpt.com/codex/tasks/task_e_68ba331fa810832fa012483c56b12c75