### PR TITLE
feat: add multi-casino and event type filters

### DIFF
--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -162,6 +162,16 @@ def register_callbacks(app, df) -> None:
         return classes
 
     @app.callback(
+        Output("selected-event-types", "data"),
+        Input("event-type-filter", "value"),
+        prevent_initial_call=True,
+    )
+    def update_event_type_filter(selected_types: list[str] | None) -> list[str]:
+        logger.debug(f"Event type filter changed: {selected_types}")
+        logger.info(f"Selected event types updated: {selected_types}")
+        return selected_types or []
+
+    @app.callback(
         Output("hotel-booking-container", "children"),
         Output("hotel-booking-container", "style"),
         Input("selected-casinos", "data"),
@@ -202,7 +212,7 @@ def register_callbacks(app, df) -> None:
         Input("week-offset", "data"),
         Input("screen-width", "data"),
         Input("selected-casinos", "data"),
-        Input("event-type-filter", "value"),
+        Input("selected-event-types", "data"),
         prevent_initial_call=True,
     )
     def render_single_week_chart(

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -134,12 +134,13 @@ def register_callbacks(app, df) -> None:
         if not selected:
             selected = []
 
-        if clicked in selected:
-            selected = []
+        selected_list = list(selected)
+        if clicked in selected_list:
+            selected_list.remove(clicked)
         else:
-            selected = [clicked]
+            selected_list.append(clicked)
 
-        return selected
+        return selected_list
 
     @app.callback(
         Output({"type": "casino-filter", "index": ALL}, "className"),
@@ -198,6 +199,7 @@ def register_callbacks(app, df) -> None:
         Input("week-offset", "data"),
         Input("screen-width", "data"),
         Input("selected-casinos", "data"),
+        Input("event-type-filter", "value"),
         prevent_initial_call=True,
     )
     def render_single_week_chart(
@@ -205,6 +207,7 @@ def register_callbacks(app, df) -> None:
         week_offset: int,
         screen_width: int,
         selected_casinos: list[str] | None,
+        selected_types: list[str] | None,
     ) -> Tuple[html.Div, list[html.Div], str, str, dict[str, Any]]:
         """Render a single week of events and overflow list."""
         today_pdt = datetime.now(PDT)
@@ -212,9 +215,12 @@ def register_callbacks(app, df) -> None:
         week_start_pdt = current_sunday + timedelta(weeks=week_offset)
         week_start = to_naive_utc(week_start_pdt)
 
-        filtered_df = (
-            df[df["Casino"].isin(selected_casinos)] if selected_casinos else df
-        )
+        filtered_df = df
+        if selected_casinos:
+            filtered_df = filtered_df[filtered_df["Casino"].isin(selected_casinos)]
+        if selected_types:
+            filtered_df = filtered_df[filtered_df["OfferType"].isin(selected_types)]
+
         grid = render_week_grid(week_start, filtered_df, screen_width, selected_casinos)
         labels = render_day_labels(week_start)
 
@@ -224,7 +230,7 @@ def register_callbacks(app, df) -> None:
         if not overflow_df.empty:
             week_start_pdt = to_pdt(week_start)
             week_end_pdt = to_pdt(week_end)
-            is_open = bool(selected_casinos)
+            is_open = bool(selected_casinos or selected_types)
             week_range = (
                 f"{week_start_pdt.strftime('%b %d')} - {week_end_pdt.strftime('%b %d')}"
             )

--- a/app_components/callbacks/filters.py
+++ b/app_components/callbacks/filters.py
@@ -130,6 +130,7 @@ def register_callbacks(app, df) -> None:
         if not ctx.triggered_id:
             raise dash.exceptions.PreventUpdate
         clicked = ctx.triggered_id.get("index")
+        logger.debug(f"Casino legend clicked: {clicked}")
 
         if not selected:
             selected = []
@@ -140,6 +141,7 @@ def register_callbacks(app, df) -> None:
         else:
             selected_list.append(clicked)
 
+        logger.info(f"Selected casinos updated: {selected_list}")
         return selected_list
 
     @app.callback(
@@ -148,6 +150,7 @@ def register_callbacks(app, df) -> None:
         State({"type": "casino-filter", "index": ALL}, "id"),
     )
     def update_legend_classes(selected, ids):
+        logger.debug(f"Updating legend classes for casinos: {selected}")
         base = "legend-item legend-button"
         selected_set = set(selected or [])
         classes = []
@@ -165,8 +168,9 @@ def register_callbacks(app, df) -> None:
     )
     def update_hotel_booking_link(selected_casinos):
         """Update hotel booking link based on selected casino."""
+        logger.debug(f"Updating hotel booking link for selection: {selected_casinos}")
         if not selected_casinos or len(selected_casinos) != 1:
-            # Hide the container if no casino or multiple casinos are selected
+            logger.debug("Hotel booking link hidden due to selection count")
             return [], {"display": "none", "textAlign": "center", "marginTop": "10px"}
 
         casino_name = selected_casinos[0]
@@ -174,7 +178,7 @@ def register_callbacks(app, df) -> None:
         booking_url = hotel_booking_sites.get(casino_name)
 
         if booking_url and booking_url != "N/A":
-            # Show the hotel booking link
+            logger.info(f"Showing hotel booking link for {casino_name}")
             link_content = html.A(
                 "🏨 Hotel Booking",
                 href=booking_url,
@@ -185,9 +189,8 @@ def register_callbacks(app, df) -> None:
                 "textAlign": "center",
                 "marginTop": "10px",
             }
-        else:
-            # Hide the container if no booking URL or N/A
-            return [], {"display": "none", "textAlign": "center", "marginTop": "10px"}
+        logger.info(f"No booking URL for {casino_name}; hiding hotel booking link")
+        return [], {"display": "none", "textAlign": "center", "marginTop": "10px"}
 
     @app.callback(
         Output("week-chart-container", "children"),
@@ -210,6 +213,14 @@ def register_callbacks(app, df) -> None:
         selected_types: list[str] | None,
     ) -> Tuple[html.Div, list[html.Div], str, str, dict[str, Any]]:
         """Render a single week of events and overflow list."""
+        ctx = dash.callback_context
+        logger.debug(
+            "Rendering week chart: offset=%s casinos=%s types=%s triggered_by=%s",
+            week_offset,
+            selected_casinos,
+            selected_types,
+            ctx.triggered_id,
+        )
         today_pdt = datetime.now(PDT)
         current_sunday = today_pdt - timedelta(days=(today_pdt.weekday() + 1) % 7)
         week_start_pdt = current_sunday + timedelta(weeks=week_offset)
@@ -217,9 +228,12 @@ def register_callbacks(app, df) -> None:
 
         filtered_df = df
         if selected_casinos:
+            logger.debug(f"Filtering events by casinos: {selected_casinos}")
             filtered_df = filtered_df[filtered_df["Casino"].isin(selected_casinos)]
         if selected_types:
+            logger.debug(f"Filtering events by types: {selected_types}")
             filtered_df = filtered_df[filtered_df["OfferType"].isin(selected_types)]
+        logger.info(f"Filtered events count: {len(filtered_df)}")
 
         grid = render_week_grid(week_start, filtered_df, screen_width, selected_casinos)
         labels = render_day_labels(week_start)

--- a/app_components/data.py
+++ b/app_components/data.py
@@ -13,6 +13,19 @@ from .utils import PDT
 logger = setup_logger(__name__)
 
 
+def _build_keyword_pattern(keys: list[str]) -> str:
+    """Return a regex pattern matching keywords with whole-word boundaries."""
+
+    whole_words: list[str] = []
+    phrases: list[str] = []
+    for key in keys:
+        if re.fullmatch(r"[A-Za-z0-9]+", key):
+            whole_words.append(rf"(?<!\w){re.escape(key)}(?!\w)")
+        else:
+            phrases.append(re.escape(key))
+    return "|".join(whole_words + phrases)
+
+
 def categorize_offer_type_updated(event_name: str | None, offer: str | None) -> str:
     """Return an offer type based on keywords found in ``event_name`` or ``offer``."""
 
@@ -33,30 +46,35 @@ def categorize_offer_type_updated(event_name: str | None, offer: str | None) -> 
     special_event_keywords = keywords["special_event_keywords"]
     vehicle_car_giveaway_keywords = keywords["vehicle_car_giveaway_keywords"]
 
+    patterns = {
+        "vehicle": re.compile(_build_keyword_pattern(vehicle_car_giveaway_keywords)),
+        "giveaway": re.compile(_build_keyword_pattern(giveaway_keywords)),
+        "free_play": re.compile(
+            _build_keyword_pattern(free_play_cash_drawing_keywords)
+        ),
+        "multiplier": re.compile(_build_keyword_pattern(multiplier_points_keywords)),
+        "hospitality": re.compile(
+            _build_keyword_pattern(hotel_travel_dining_shopping_keywords)
+        ),
+        "special": re.compile(_build_keyword_pattern(special_event_keywords)),
+    }
+
     # Check for categories in a specific order of precedence
-    if any(keyword in event_name for keyword in vehicle_car_giveaway_keywords) or any(
-        keyword in offer for keyword in vehicle_car_giveaway_keywords
-    ):
+    if patterns["vehicle"].search(event_name) or patterns["vehicle"].search(offer):
         return "Giveaway"
-    elif any(keyword in event_name for keyword in giveaway_keywords) or any(
-        keyword in offer for keyword in giveaway_keywords
-    ):
+    if patterns["giveaway"].search(event_name) or patterns["giveaway"].search(offer):
         return "Giveaway"
-    elif any(
-        keyword in event_name for keyword in free_play_cash_drawing_keywords
-    ) or any(keyword in offer for keyword in free_play_cash_drawing_keywords):
+    if patterns["free_play"].search(event_name) or patterns["free_play"].search(offer):
         return "Free-Play"
-    elif any(keyword in event_name for keyword in multiplier_points_keywords) or any(
-        keyword in offer for keyword in multiplier_points_keywords
+    if patterns["multiplier"].search(event_name) or patterns["multiplier"].search(
+        offer
     ):
         return "Point-Based"
-    elif any(
-        keyword in event_name for keyword in hotel_travel_dining_shopping_keywords
-    ) or any(keyword in offer for keyword in hotel_travel_dining_shopping_keywords):
-        return "Hospitality-Rewards"
-    elif any(keyword in event_name for keyword in special_event_keywords) or any(
-        keyword in offer for keyword in special_event_keywords
+    if patterns["hospitality"].search(event_name) or patterns["hospitality"].search(
+        offer
     ):
+        return "Hospitality-Rewards"
+    if patterns["special"].search(event_name) or patterns["special"].search(offer):
         return "Special-Events"
 
     return "Offer"
@@ -79,8 +97,10 @@ def categorize_offer_types(df: pd.DataFrame) -> pd.Series:
     category = pd.Series("Offer", index=df.index)
 
     def match(keys: list[str]) -> pd.Series:
-        pattern = "|".join(map(re.escape, keys))
-        return event_name.str.contains(pattern) | offer.str.contains(pattern)
+        pattern = _build_keyword_pattern(keys)
+        return event_name.str.contains(pattern, regex=True) | offer.str.contains(
+            pattern, regex=True
+        )
 
     masks = {
         "vehicle": match(keywords["vehicle_car_giveaway_keywords"]),

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -52,6 +52,7 @@ def create_layout(app, df):
                 dcc.Store(id="overflow-date"),
                 dcc.Store(id="animation-refresh"),
                 dcc.Store(id="selected-casinos", data=[]),
+                dcc.Store(id="selected-event-types", data=[]),
                 dcc.Store(id="last-day-date", data=None),
                 dcc.Store(id="reopen-day-on-close", data=False),
                 dcc.Store(id="theme-store", data="light", storage_type="local"),

--- a/app_components/layout.py
+++ b/app_components/layout.py
@@ -210,6 +210,17 @@ def sticky_header(df):
                                 className="legend-title legend-gap",
                             ),
                             html.Div(create_legend(df), className="legend-container"),
+                            dcc.Dropdown(
+                                id="event-type-filter",
+                                options=[
+                                    {"label": t, "value": t}
+                                    for t in sorted(df["OfferType"].dropna().unique())
+                                ],
+                                multi=True,
+                                placeholder="Filter by event type",
+                                className="event-type-dropdown",
+                                value=[],
+                            ),
                             # Hotel booking link that appears when a casino is selected
                             html.Div(
                                 id="hotel-booking-container",

--- a/assets/styles/_animations.scss
+++ b/assets/styles/_animations.scss
@@ -67,7 +67,7 @@
 
     to {
         transform: translateY(0);
-        opacity: 1 !important;
+        opacity: 1;
     }
 }
 

--- a/assets/styles/_components.scss
+++ b/assets/styles/_components.scss
@@ -86,6 +86,24 @@ h1,
     background-color: var(--color-accent-light);
 }
 
+/* stylelint-disable selector-class-pattern */
+.event-type-dropdown {
+    width: 100%;
+
+    .Select-control,
+    .Select-menu-outer,
+    .Select-menu {
+        background-color: var(--color-background);
+    }
+
+    .Select-value-label,
+    .Select-placeholder,
+    .Select-option {
+        color: var(--color-accent);
+    }
+}
+/* stylelint-enable selector-class-pattern */
+
 /* Hotel booking link styles */
 #hotel-booking-container a {
     display: inline-block;
@@ -281,6 +299,22 @@ h1,
         outline: var(--border-thin) solid var(--color-primary);
         background-color: var(--color-primary);
     }
+
+    /* stylelint-disable selector-class-pattern */
+    .event-type-dropdown {
+        .Select-control,
+        .Select-menu-outer,
+        .Select-menu {
+            background-color: var(--color-background);
+        }
+
+        .Select-value-label,
+        .Select-placeholder,
+        .Select-option {
+            color: var(--color-primary);
+        }
+    }
+    /* stylelint-enable selector-class-pattern */
 
     #hotel-booking-container a {
         color: var(--color-primary);

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -36,9 +36,9 @@
     --color-accent: #6A5ACD;
     --color-accent-dark: #483D8B;
     --color-background: #f5f3fa;
-    --color-white: #ffffff;
-    --color-black: #000000;
-    --color-accent-light: rgba(106, 90, 205, 0.1);
+    --color-white: #fff;
+    --color-black: #000;
+    --color-accent-light: rgb(106 90 205 / 10%);
 
     /* Day Header & Week Grid Colors */
     --color-day-header-text: var(--color-accent);
@@ -46,7 +46,7 @@
     --color-border-primary: var(--color-primary-dark);
     --color-border-accent: var(--color-accent);
     --color-border-grid: #7F8BAA;
-    --color-border-grid-light: rgba(127, 139, 170, 0.3);
+    --color-border-grid-light: rgb(127 139 170 / 30%);
 
     /* Borders and shadows */
     --border-radius-lg: 0.625rem;
@@ -74,7 +74,7 @@
     --day-modal-min-width: 18rem;
     --day-modal-max-width-desktop: 70rem;
     --day-modal-max-width-hd: 90rem;
-    --modal-overlay-color: rgba(0, 0, 0, 0.25);
+    --modal-overlay-color: rgb(0 0 0 / 25%);
     --modal-overlay-blur: 0.25rem;
 
     /* Animation distances */
@@ -92,7 +92,7 @@
 }
 
 /* Font and spacing adjustments for small screens */
-@media (max-width: 480px) {
+@media (width <= 480px) {
     :root {
         --font-xxs: 0.35rem;
         --font-xs: 0.45rem;
@@ -105,7 +105,7 @@
 }
 
 /* Slightly larger fonts for landscape phones */
-@media (max-width: 896px) and (orientation: landscape) {
+@media (width <= 896px) and (orientation: landscape) {
     :root {
         --font-xxs: 0.45rem;
         --font-xs: 0.55rem;
@@ -163,7 +163,7 @@ body {
     /* Main primary used instead of accent in dark */
     --color-primary-dark: #6a5acd;
     /* Supporting tone for shadows/borders */
-    --color-primary-light: rgba(106, 90, 205, 0.15);
+    --color-primary-light: rgb(106 90 205 / 15%);
     /* Subtle primary-tinted backgrounds */
 
     /* Base text/background tokens */
@@ -177,17 +177,13 @@ body {
     --color-day-header-bg: #2d2d30;
     --color-border-primary: #7dd3fc;
     --color-border-grid: #7dd3fc;
-    --color-border-grid-light: rgb(125 211 252 / 0.3);
+    --color-border-grid-light: rgb(125 211 252 / 30%);
 
     /* Shadows - light blue-ish */
-    --box-shadow-light: 0 -0.125rem 0.3125rem rgb(125 211 252 / 0.4);
-    --box-shadow-modal: 0 0 1.25rem rgb(125 211 252 / 0.2);
-    --box-shadow-subtle: 0 -0.0625rem 0.3125rem rgba(125, 211, 252, 0.3);
-}
-
-/* Global override to soften casino colors in dark mode */
-[data-theme="dark"] {
-
+    --box-shadow-light: 0 -0.125rem 0.3125rem rgb(125 211 252 / 40%);
+    --box-shadow-modal: 0 0 1.25rem rgb(125 211 252 / 20%);
+    --box-shadow-subtle: 0 -0.0625rem 0.3125rem rgb(125 211 252 / 30%);
+    /* Global override to soften casino colors in dark mode */
     .event-block-grid,
     .event-block-day {
         z-index: 25 !important;

--- a/data/offer_keywords.json
+++ b/data/offer_keywords.json
@@ -78,7 +78,9 @@
     "travel",
     "trip",
     "room night",
+    "complimentary night",
     "standard room",
+    "complimentary stay",
     "double rewards",
     "% off"
   ],

--- a/data/offer_keywords.json
+++ b/data/offer_keywords.json
@@ -111,7 +111,9 @@
     "jetta",
     "kia k5",
     "dodge charger",
-    "rv",
+    "rv giveaway",
+    "win an rv",
+    "rv drawing",
     "atv",
     "truck",
     "land cruiser"

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 from app_components.callbacks import register_callbacks
 from app_components.utils import to_naive_utc
-from dash import Dash
+from dash import Dash, html
 from freezegun import freeze_time
 
 
@@ -98,19 +98,83 @@ def test_toggle_overflow(monkeypatch, casino):
 
 @pytest.mark.usefixtures("casino")
 def test_toggle_casino_filter(monkeypatch, casino):
-    df = pd.DataFrame({"EventName": ["E1"], "Casino": [casino]})
+    other = "Another Casino"
+    df = pd.DataFrame({"EventName": ["E1", "E2"], "Casino": [casino, other]})
     app = Dash(__name__)
     register_callbacks(app, df)
     func = app.callback_map["selected-casinos.data"]["callback"].__wrapped__
+
+    ids = [
+        {"type": "casino-filter", "index": casino},
+        {"type": "casino-filter", "index": other},
+    ]
 
     monkeypatch.setattr(
         "dash.callback_context",
         DummyCtx({"type": "casino-filter", "index": casino}),
         raising=False,
     )
+    selected = func([1, 0], ids, [])
+    assert selected == [casino]
 
-    result = func([1], [{"type": "casino-filter", "index": casino}], [])
-    assert result == [casino]
+    monkeypatch.setattr(
+        "dash.callback_context",
+        DummyCtx({"type": "casino-filter", "index": other}),
+        raising=False,
+    )
+    selected = func([1, 1], ids, selected)
+    assert set(selected) == {casino, other}
+
+    monkeypatch.setattr(
+        "dash.callback_context",
+        DummyCtx({"type": "casino-filter", "index": casino}),
+        raising=False,
+    )
+    selected = func([2, 1], ids, selected)
+    assert selected == [other]
+
+
+def test_event_type_filter(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "EventName": ["E1", "E2"],
+            "Casino": ["A", "A"],
+            "Location": ["L", "L"],
+            "Offer": ["", ""],
+            "StartDate": [
+                to_naive_utc(datetime(2025, 4, 14)),
+                to_naive_utc(datetime(2025, 4, 14)),
+            ],
+            "EndDate": [
+                to_naive_utc(datetime(2025, 4, 15)),
+                to_naive_utc(datetime(2025, 4, 15)),
+            ],
+            "OfferType": ["Giveaway", "Free-Play"],
+        }
+    )
+
+    captured: dict[str, pd.DataFrame] = {}
+
+    def fake_render_week_grid(week_start, fdf, screen_width, selected_casinos):
+        captured["df"] = fdf
+        return html.Div()
+
+    app = Dash(__name__)
+    register_callbacks(app, df)
+    monkeypatch.setattr(
+        "app_components.callbacks.filters.render_week_grid",
+        fake_render_week_grid,
+    )
+    func = app.callback_map[
+        (
+            "..week-chart-container.children...day-label-row.children..."
+            "overflow-date.data...animation-refresh.data...calendar-scroll-body.style.."
+        )
+    ]["callback"].__wrapped__
+
+    func(600, 0, 1024, [], ["Giveaway"])
+    assert len(captured["df"]) == 1
+    assert captured["df"]["OfferType"].iloc[0] == "Giveaway"
 
 
 @pytest.mark.usefixtures("casino")

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -172,6 +172,12 @@ def test_event_type_filter(monkeypatch):
         )
     ]["callback"].__wrapped__
 
+    monkeypatch.setattr(
+        "dash.callback_context",
+        DummyCtx("event-type-filter"),
+        raising=False,
+    )
+
     func(600, 0, 1024, [], ["Giveaway"])
     assert len(captured["df"]) == 1
     assert captured["df"]["OfferType"].iloc[0] == "Giveaway"

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -174,13 +174,22 @@ def test_event_type_filter(monkeypatch):
 
     monkeypatch.setattr(
         "dash.callback_context",
-        DummyCtx("event-type-filter"),
+        DummyCtx("selected-event-types"),
         raising=False,
     )
 
     func(600, 0, 1024, [], ["Giveaway"])
     assert len(captured["df"]) == 1
     assert captured["df"]["OfferType"].iloc[0] == "Giveaway"
+
+
+def test_update_event_type_filter():
+    app = Dash(__name__)
+    register_callbacks(app, pd.DataFrame())
+    func = app.callback_map["selected-event-types.data"]["callback"].__wrapped__
+
+    assert func(["Giveaway"]) == ["Giveaway"]
+    assert func(None) == []
 
 
 @pytest.mark.usefixtures("casino")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,6 +12,8 @@ from app_components.data import categorize_offer_type_updated, load_event_data
         ("", "free play bonus", "Free-Play"),
         ("Points Multiplier", "", "Point-Based"),
         ("Hotel Stay", "", "Hospitality-Rewards"),
+        ("Complimentary Night", "", "Hospitality-Rewards"),
+        ("Complimentary Stay", "", "Hospitality-Rewards"),
         ("Tournament", "", "Special-Events"),
         ("Generic Promo", "", "Offer"),
     ],

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-from app_components.data import categorize_offer_type_updated, load_event_data
+from app_components.data import (
+    categorize_offer_type_updated,
+    categorize_offer_types,
+    load_event_data,
+)
 
 
 @pytest.mark.parametrize(
@@ -14,6 +18,9 @@ from app_components.data import categorize_offer_type_updated, load_event_data
         ("Hotel Stay", "", "Hospitality-Rewards"),
         ("Complimentary Night", "", "Hospitality-Rewards"),
         ("Complimentary Stay", "", "Hospitality-Rewards"),
+        ("RV Stay", "", "Hospitality-Rewards"),
+        ("Win an RV", "", "Giveaway"),
+        ("Reservation Bonus", "", "Offer"),
         ("Tournament", "", "Special-Events"),
         ("Generic Promo", "", "Offer"),
     ],
@@ -87,3 +94,18 @@ def test_load_event_data_handles_dst_fall(tmp_path: Path, casino):
 
     delta = result.loc[0, "EndDate"] - result.loc[0, "StartDate"]
     assert delta.total_seconds() == 10800
+
+
+def test_categorize_offer_types_word_boundaries():
+    df = pd.DataFrame(
+        {
+            "EventName": ["RV Stay", "Reservation Bonus", "Win an RV"],
+            "Offer": ["", "", ""],
+        }
+    )
+    result = categorize_offer_types(df)
+    assert list(result) == [
+        "Hospitality-Rewards",
+        "Offer",
+        "Giveaway",
+    ]


### PR DESCRIPTION
## Summary
- allow selecting multiple casinos in legend
- add dropdown to filter events by offer type
- cover new filter behaviors with tests

## Testing
- `python -m py_compile app.py app_components/*.py`
- `black --check app_components/callbacks/filters.py app_components/layout.py tests/test_callbacks.py`
- `isort --check-only --settings-path config/.isort.cfg app_components/callbacks/filters.py app_components/layout.py tests/test_callbacks.py`
- `flake8 --config config/.flake8 app_components/callbacks/filters.py app_components/layout.py tests/test_callbacks.py`
- `npm run lint:css` *(fails: Unexpected !important and color notation issues)*
- `pytest -vv -s tests/`

------
https://chatgpt.com/codex/tasks/task_e_68c747de9acc832fa7f263484d931cb7