### PR TITLE
fix: align windows launchers with new scripts layout

### DIFF
--- a/cleanup.bat
+++ b/cleanup.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Casino Calendar - Log Cleanup Launcher
-REM Calls the log cleanup utility from tools directory
+REM Proxies to the Windows log cleanup utility in scripts\windows
 
 echo Starting Casino Calendar Log Cleanup...
 call "scripts\windows\cleanup_logs.bat" %*

--- a/run.bat
+++ b/run.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Casino Calendar - Quick Run Launcher
-REM Calls the main application runner from tools directory
+REM Proxies to the main Windows runner script in scripts\windows
 
 echo Starting Casino Calendar Application...
-call "tools\run_direct.bat"
+call "scripts\windows\run_direct.bat"

--- a/scripts/windows/setup.bat
+++ b/scripts/windows/setup.bat
@@ -89,7 +89,7 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 del /f /q "%ROOT_DIR%\.tmp_requirements_diff.txt" 2>nul
-"%PYTHON_EXE%" "%ROOT_DIR%\scripts\verify_requirements.py" > "%ROOT_DIR%\.tmp_requirements_diff.txt"
+"%PYTHON_EXE%" "%ROOT_DIR%\scripts\python\verify_requirements.py" > "%ROOT_DIR%\.tmp_requirements_diff.txt"
 set "REQS_OUT_OF_SYNC=%ERRORLEVEL%"
 set "REQS_OUT_OF_SYNC=%ERRORLEVEL%"
 

--- a/setup.bat
+++ b/setup.bat
@@ -1,6 +1,6 @@
 @echo off
-REM Casino Calendar - Quick Setup Launcher  
-REM Calls the setup script from tools directory
+REM Casino Calendar - Quick Setup Launcher
+REM Proxies to the Windows setup script in scripts\windows
 
 echo Running Casino Calendar Setup...
 call "scripts\windows\setup.bat"


### PR DESCRIPTION
## Summary
- point the root Windows launcher scripts at the new scripts\windows locations
- fix the Windows setup routine to reference scripts\python\verify_requirements.py after the restructure

## Testing
- not run (batch-script only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d0c8cc9c8c832f86bdc093cd81419a